### PR TITLE
Fallback to determine linux distribution in case of lsb_release is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If there are enabled package managers that you absolutely hate and want out of t
 
 `Other distros`:
 
-Some distros are easily supported by just simply identifying them under each of the 3 base distros respectively so if there's a distro that it doesn't support already, feel free to submit an issue including the output of `lsb_release -a` to request for it to be added and I will try to find time to get it added on.
+Some distros are easily supported by just simply identifying them under each of the 3 base distros respectively so if there's a distro that it doesn't support already, feel free to submit an issue including the output of `cat /etc/*-release` to request for it to be added and I will try to find time to get it added on.
 
 Also, I primarily use Pop, Ubuntu, Debian, Fedora, Arch, and Garuda so other distros are a bit less tested. If you notice any issues on the other "supported" distros, please let me know by submitting an issue here.
 
@@ -143,7 +143,7 @@ The go, pip, and cargo support is not meant to be a replacement for development 
 ### INSTALL
 
 1. Make sure all the package managers you want app to manage and are installed and configured properly
-2. Install `git` and `lsb_release` manually if it's not already installed
+2. Install `git` manually if it's not already installed
 3. cd into a directory of choice where you want to keep the app repo. If you are an end user and can't decide, I suggest `~/.config` (`mkdir ~/.config` if it doesn't already exist)
 4. `git clone https://github.com/hkdb/app.git`
 5. `cd app`

--- a/arch/pacman.go
+++ b/arch/pacman.go
@@ -107,7 +107,7 @@ func Update() {
 func Upgrade() {
 
 	switch env.Distro {
-	case "Garuda":
+	case "garuda":
 		upgrade := exec.Command("/usr/bin/garuda-update")
 		utils.RunCmd(upgrade, "Upgrade Error:")
 	default:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,7 +1,7 @@
 ## INSTALL
 
 1. Make sure all the package managers you want app to manage are installed and configured properly
-2. Install `git` and `lsb_release` manually if it's not already installed
+2. Install `git` manually if it's not already installed
 3. cd into a directory of choice where you want to keep the app repo. If you are an end user and can't decide, I suggest `~/.config` (`mkdir ~/.config` if it doesn't already exist)
 4. `git clone https://github.com/hkdb/app.git`
 5. `cd app`

--- a/install.sh
+++ b/install.sh
@@ -53,25 +53,16 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   OSRNV=${OSR:5}
   DIST=${OSRNV:1:${#OSRNV}-2}
 
-  if [[ ! -f /usr/bin/lsb_release ]]; then
-    if [[ "$DIST" == "Fedora Linux" ]]; then
-      echo -e "\nInstalling lsb_release\n"
-      sudo dnf install lsb_release
-    else
-      echo -e "\nlsb_release is not installed. Install it before you run this script again... Exiting..."
-      exit 1
-    fi
-  fi
   echo -e "\nOS: Linux\n"
-  DISTRO=$(lsb_release -i -s)
+  DISTRO=$(cat /etc/*-release | grep "^ID=" | head -1 | cut -d '=' -f 2)
 
-  if [[ "$DISTRO" == "Debian" ]] || [[ "$DISTRO" == "Ubuntu" ]] || [[ "$DISTRO" == "Pop" ]] || [[ "$DISTRO" == "Linuxmint" ]]; then
+  if [[ "$DISTRO" == "debian" ]] || [[ "$DISTRO" == "ubuntu" ]] || [[ "$DISTRO" == "pop" ]] || [[ "$DISTRO" == "linuxmint" ]]; then
     PKGMGR="apt"
     IFLAG="install"
-  elif [[ "$DISTRO" == "Fedora" ]] || [[ "$DISTRO" == "Rocky" ]] || [[ "$DISTRO" == "AlmaLinux" ]] || [[ "$DISTRO" == "CentOS" ]] || [[ "$DISTRO" == "RedHatEnterpriseServer" ]] || [[  "$DISTRO" == "Oracle" ]] || [[ "$DISTRO" == "ClearOS" ]] || [[ "$DISTRO" == "AmazonAMI" ]]; then
+  elif [[ "$DISTRO" == "fedora" ]] || [[ "$DISTRO" == "rocky" ]] || [[ "$DISTRO" == "almalinux" ]] || [[ "$DISTRO" == "centos" ]] || [[ "$DISTRO" == "RedHatEnterpriseServer" ]] || [[  "$DISTRO" == "ol" ]] || [[ "$DISTRO" == "clear-linux-os" ]] || [[ "$DISTRO" == "AmazonAMI" ]]; then
     PKGMGR="dnf"
     IFLAG="install"
-  elif [[ "$DISTRO" == "Arch" ]] || [[ "$DISTRO" == "Garuda" ]] || [[ "$DISTRO" == "Manjaro" ]] || [[ "$DISTRO" == "Endeavour" ]]; then
+  elif [[ "$DISTRO" == "arch" ]] || [[ "$DISTRO" == "garuda" ]] || [[ "$DISTRO" == "manjaro" ]] || [[ "$DISTRO" == "Endeavour" ]]; then
     PKGMGR="pacman"
     IFLAG="-S"
   fi
@@ -79,7 +70,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   read -p "Would you like to install Flatpak? (Y/n) " FLATPAK
   if [[ $FLATPAK != "N" ]] && [[ $FLATPAK != "n" ]]; then
    sudo $PKGMGR $IFLAG flatpak
-   if [[ "$DISTRO" == "Arch" ]] || [[ "$DISTRO" == "Garuda" ]] || [[ "$DISTRO" == "Manjaro" ]] || [[ "$DISTRO" == "Endeavour" ]]; then
+   if [[ "$DISTRO" == "arch" ]] || [[ "$DISTRO" == "garuda" ]] || [[ "$DISTRO" == "manjaro" ]] || [[ "$DISTRO" == "Endeavour" ]]; then
     U=$USER
     sudo adduser $U _flatpak
     sudo flatpak repair
@@ -89,7 +80,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 
   read -p "Would you like to install Snap? (Y/n) " SNAP
   if [[ $SNAP != "N" ]] && [[ $SNAP != "n" ]]; then
-    if [[ "$DISTRO" == "Arch" ]] || [[ "$DISTRO" == "Garuda" ]] || [[ "$DISTRO" == "Manjaro" ]] || [[ "$DISTRO" == "Endeavour" ]]; then
+    if [[ "$DISTRO" == "arch" ]] || [[ "$DISTRO" == "garuda" ]] || [[ "$DISTRO" == "manjaro" ]] || [[ "$DISTRO" == "Endeavour" ]]; then
       OPATH=$(pwd)
       cd /tmp/
       git clone https://aur.archlinux.org/snapd.git
@@ -106,7 +97,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   fi
 
   echo -e "\n"
-  if [[ "$DISTRO" == "Linuxmint" ]] || [[ "$DISTRO" == "Debian" ]]; then
+  if [[ "$DISTRO" == "linuxmint" ]] || [[ "$DISTRO" == "debian" ]]; then
     read -p  "Add software-properties-common? (Y/n) " SPC
     if [[ "$SPC" != "N" ]] && [[ "$SPC" != "n" ]]; then
 			sudo apt install software-properties-common
@@ -114,7 +105,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   fi
    
   echo -e "\n"
-  if [[ "$DISTRO" == "Debian" ]] || [[ "$DISTRO" == "Ubuntu" ]] || [[ "$DISTRO" == "Pop" ]]; then
+  if [[ "$DISTRO" == "debian" ]] || [[ "$DISTRO" == "ubuntu" ]] || [[ "$DISTRO" == "pop" ]]; then
     read -p  "Add longsleep-ubuntu-golang-backports? (Y/n) " BACKPORTS
     if [[ "$BACKPORTS" != "N" ]] && [[ "$BACKPORTS" != "n" ]]; then
       # sudo echo -e "deb https://ppa.launchpadcontent.net/longsleep/golang-backports/ubuntu/ jammy main\n# deb-src https://ppa.launchpadcontent.net/longsleep/golang-backports/ubuntu/ jammy main" |sudo tee /etc/apt/sources.list.d/longsleep-ubuntu-golang-backports-jammy.list
@@ -126,7 +117,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
    
   read -p  "Install Go 1.21? Only say no if you already have it installed... (Y/n) " GOLANG
   if [[ "$GOLANG" != "N" ]] && [[ "$GOLANG" != "n" ]]; then
-		if [[ "$DISTRO" == "Fedora" ]] || [[ "$DISTRO" == "Rocky" ]] || [[ "$DISTRO" == "AlmaLinux" ]] || [[ "$DISTRO" == "CentOS" ]] || [[ "$DISTRO" == "RedHatEnterpriseServer" ]] || [[  "$DISTRO" == "Oracle" ]] || [[ "$DISTRO" == "ClearOS" ]] || [[ "$DISTRO" == "AmazonAMI" ]]; then
+		if [[ "$DISTRO" == "fedora" ]] || [[ "$DISTRO" == "rocky" ]] || [[ "$DISTRO" == "almalinux" ]] || [[ "$DISTRO" == "centos" ]] || [[ "$DISTRO" == "RedHatEnterpriseServer" ]] || [[  "$DISTRO" == "ol" ]] || [[ "$DISTRO" == "clear-linux-os" ]] || [[ "$DISTRO" == "AmazonAMI" ]]; then
 			wget -O /tmp/go1.21.5.linux-amd64.tar.gz https://go.dev/dl/go1.21.5.linux-amd64.tar.gz  
 			sudo tar -C /usr/local -xzf /tmp/go1.21.5.linux-amd64.tar.gz
 			export PATH=$PATH:/usr/local/go/bin


### PR DESCRIPTION
I have added a fallback to determine the current linux distribution in case where `lsb_release` is missing.

Sorry for introducing `golang.org/x/text` but it was necessary to capitalize the result (I would have prefer you using only lower cases for comparisons but I respect your choice) otherwise using `strings.Title` would have introduced a deprecated and I prefered not to do that.

I love the way you've organized your code. =)

Edit:
I didn't want to remove completely `lsb_release` but I can if you prefer.

Edit2:
Im currently testing the behavior on different distribution (thanks `distrobox`) and I have a different result on Linux Mint, LinuxMint / Linuxmint.

I renew my position about using only lower cases for comparisons (or I apply Edit 1). Let me know.

Edit 3:
Testing `lsb_release` on `amazonlinux` return `n/a` so I am definitively for Edit 1.

Edit 4:
I have extracted the result of `cat /etc/*-release` from those distribs so far:
<details>
<summary>result</summary>

DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=24.04
DISTRIB_CODENAME=noble
DISTRIB_DESCRIPTION="Ubuntu 24.04 LTS"
PRETTY_NAME="Ubuntu 24.04 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo



DISTRIB_ID=Pop
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Pop!_OS 22.04 LTS"
NAME="Pop!_OS"
VERSION="22.04 LTS"
ID=pop
ID_LIKE="ubuntu debian"
PRETTY_NAME="Pop!_OS 22.04 LTS"
VERSION_ID="22.04"
HOME_URL="https://pop.system76.com"
SUPPORT_URL="https://support.system76.com"
BUG_REPORT_URL="https://github.com/pop-os/pop/issues"
PRIVACY_POLICY_URL="https://system76.com/privacy"
VERSION_CODENAME=jammy
UBUNTU_CODENAME=jammy
LOGO=distributor-logo-pop-os



PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"



DISTRIB_ID=LinuxMint
DISTRIB_RELEASE=21.3
DISTRIB_CODENAME=virginia
DISTRIB_DESCRIPTION="Linux Mint 21.3 Virginia"
NAME="Linux Mint"
VERSION="21.3 (Virginia)"
ID=linuxmint
ID_LIKE="ubuntu debian"
PRETTY_NAME="Linux Mint 21.3"
VERSION_ID="21.3"
HOME_URL="https://www.linuxmint.com/"
SUPPORT_URL="https://forums.linuxmint.com/"
BUG_REPORT_URL="http://linuxmint-troubleshooting-guide.readthedocs.io/en/latest/"
PRIVACY_POLICY_URL="https://www.linuxmint.com/"
VERSION_CODENAME=virginia
UBUNTU_CODENAME=jammy


Fedora release 39 (Thirty Nine)
NAME="Fedora Linux"
VERSION="39 (Container Image)"
ID=fedora
VERSION_ID=39
VERSION_CODENAME=""
PLATFORM_ID="platform:f39"
PRETTY_NAME="Fedora Linux 39 (Container Image)"
ANSI_COLOR="0;38;2;60;110;180"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:fedoraproject:fedora:39"
DEFAULT_HOSTNAME="fedora"
HOME_URL="https://fedoraproject.org/"
DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/f39/system-administrators-guide/"
SUPPORT_URL="https://ask.fedoraproject.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=39
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=39
SUPPORT_END=2024-11-12
VARIANT="Container Image"
VARIANT_ID=container
Fedora release 39 (Thirty Nine)
Fedora release 39 (Thirty Nine)



NAME="Rocky Linux"
VERSION="9.3 (Blue Onyx)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="9.3"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Rocky Linux 9.3 (Blue Onyx)"
ANSI_COLOR="0;32"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:rocky:rocky:9::baseos"
HOME_URL="https://rockylinux.org/"
BUG_REPORT_URL="https://bugs.rockylinux.org/"
SUPPORT_END="2032-05-31"
ROCKY_SUPPORT_PRODUCT="Rocky-Linux-9"
ROCKY_SUPPORT_PRODUCT_VERSION="9.3"
REDHAT_SUPPORT_PRODUCT="Rocky Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.3"
Rocky Linux release 9.3 (Blue Onyx)
Rocky Linux release 9.3 (Blue Onyx)
Rocky Linux release 9.3 (Blue Onyx)



AlmaLinux release 9.4 (Seafoam Ocelot)
NAME="AlmaLinux"
VERSION="9.4 (Seafoam Ocelot)"
ID="almalinux"
ID_LIKE="rhel centos fedora"
VERSION_ID="9.4"
PLATFORM_ID="platform:el9"
PRETTY_NAME="AlmaLinux 9.4 (Seafoam Ocelot)"
ANSI_COLOR="0;34"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:almalinux:almalinux:9::baseos"
HOME_URL="https://almalinux.org/"
DOCUMENTATION_URL="https://wiki.almalinux.org/"
BUG_REPORT_URL="https://bugs.almalinux.org/"
ALMALINUX_MANTISBT_PROJECT="AlmaLinux-9"
ALMALINUX_MANTISBT_PROJECT_VERSION="9.4"
REDHAT_SUPPORT_PRODUCT="AlmaLinux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.4"
SUPPORT_END=2032-06-01
AlmaLinux release 9.4 (Seafoam Ocelot)
AlmaLinux release 9.4 (Seafoam Ocelot)



CentOS Linux release 7.9.2009 (Core)
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"
CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"
CentOS Linux release 7.9.2009 (Core)
CentOS Linux release 7.9.2009 (Core)



Oracle Linux Server release 9.4
NAME="Oracle Linux Server"
VERSION="9.4"
ID="ol"
ID_LIKE="fedora"
VARIANT="Server"
VARIANT_ID="server"
VERSION_ID="9.4"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Oracle Linux Server 9.4"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:oracle:linux:9:4:server"
HOME_URL="https://linux.oracle.com/"
BUG_REPORT_URL="https://github.com/oracle/oracle-linux"
ORACLE_BUGZILLA_PRODUCT="Oracle Linux 9"
ORACLE_BUGZILLA_PRODUCT_VERSION=9.4
ORACLE_SUPPORT_PRODUCT="Oracle Linux"
ORACLE_SUPPORT_PRODUCT_VERSION=9.4
Red Hat Enterprise Linux release 9.4 (Plow)
Oracle Linux Server release 9.4



NAME="Clear Linux OS"
VERSION=1
ID=clear-linux-os
ID_LIKE=clear-linux-os
VERSION_ID=41730
PRETTY_NAME="Clear Linux OS"
ANSI_COLOR="1;35"
HOME_URL="https://clearlinux.org"
SUPPORT_URL="https://clearlinux.org"
BUG_REPORT_URL="mailto:dev@clearlinux.discoursemail.com"
PRIVACY_POLICY_URL="http://www.intel.com/privacy"
BUILD_ID=41730



Amazon Linux release 2023.4.20240513 (Amazon Linux)
NAME="Amazon Linux"
VERSION="2023"
ID="amzn"
ID_LIKE="fedora"
VERSION_ID="2023"
PLATFORM_ID="platform:al2023"
PRETTY_NAME="Amazon Linux 2023.4.20240513"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2023"
HOME_URL="https://aws.amazon.com/linux/amazon-linux-2023/"
DOCUMENTATION_URL="https://docs.aws.amazon.com/linux/"
SUPPORT_URL="https://aws.amazon.com/premiumsupport/"
BUG_REPORT_URL="https://github.com/amazonlinux/amazon-linux-2023"
VENDOR_NAME="AWS"
VENDOR_URL="https://aws.amazon.com/"
SUPPORT_END="2028-03-15"
Amazon Linux release 2023.4.20240513 (Amazon Linux)



NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
BUILD_ID=rolling
VERSION_ID=20240101.0.204074
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://archlinux.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://bugs.archlinux.org/"
PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
LOGO=archlinux-logo



Manjaro Linux
DISTRIB_ID="ManjaroLinux"
DISTRIB_RELEASE="24.0.0"
DISTRIB_CODENAME="Wynsdey"
DISTRIB_DESCRIPTION="Manjaro Linux"
Manjaro Linux
NAME="Manjaro Linux"
PRETTY_NAME="Manjaro Linux"
ID=manjaro
ID_LIKE=arch
BUILD_ID=rolling
ANSI_COLOR="32;1;24;144;200"
HOME_URL="https://manjaro.org/"
DOCUMENTATION_URL="https://wiki.manjaro.org/"
SUPPORT_URL="https://forum.manjaro.org/"
BUG_REPORT_URL="https://docs.manjaro.org/reporting-bugs/"
PRIVACY_POLICY_URL="https://manjaro.org/privacy-policy/"
LOGO=manjarolinux
</details>

I am torn between using directly the `ID` but less pretty or the `NAME` with some cleaning.