### PR TITLE
Github: add workflow support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags: '*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        os: [darwin, linux, windows]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.4'
+
+      - name: Install dependencies
+        run: |
+          go mod download
+
+      - name: Build
+        run: |
+          GOARCH=${{ matrix.arch }} GOOS=${{ matrix.os }} go build -o app-${{ matrix.os }}-${{ matrix.arch }} ./main.go
+
+      # Tried gzip but without succeding of keeping execute permissions
+      - name: Zip
+        run: |
+          zip app-${{ matrix.os }}-${{ matrix.arch }}.zip app-${{ matrix.os }}-${{ matrix.arch }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: app-${{ matrix.os }}-${{ matrix.arch }}.zip
+          path: |
+            app-${{ matrix.os }}-${{ matrix.arch }}.zip
+          retention-days: 1
+
+  publish:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      # Must perform checkout first, since it deletes the target directory
+      # before running, and would therefore delete the downloaded artifacts
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+
+      - name: Publish release
+        run: |
+          TAG_NAME=${{ github.ref_name }}
+          gh release create $TAG_NAME --prerelease --title "$TAG_NAME" --target $GITHUB_SHA \
+            app-*/*

--- a/cargo/cargo.go
+++ b/cargo/cargo.go
@@ -16,7 +16,7 @@ func Install(pkg, tag string) {
 	isUrl := utils.IsUrl(pkg)
 	p := pkg
 	if isUrl == true {
-		pRaw := utils.GetFileFromUrl(pkg)
+		_, pRaw := utils.GetFileFromUrl(pkg)
 		pExt := utils.GetFileExtension(pRaw)
 		p = pRaw
 		if pExt == ".git" {

--- a/utils/http.go
+++ b/utils/http.go
@@ -5,11 +5,10 @@ import (
 	"path"
 )
 
-func GetFileFromUrl(url string) string {
+func GetFileFromUrl(url string) (string, string) {
 
-		r,_ := http.NewRequest("GET", url, nil)
-		file := path.Base(r.URL.Path)
+	r, _ := http.Get(url)
+	file := path.Base(r.Request.URL.Path)
 
-		return file
-
+	return r.Request.URL.String(), file
 }

--- a/utils/output.go
+++ b/utils/output.go
@@ -1,8 +1,8 @@
 package utils
 
 import (
-	"log"
 	"fmt"
+	"log"
 	"os"
 )
 
@@ -41,9 +41,23 @@ _____  ______ ______
 	log.Println(string(ColorCyan), logo, string(ColorReset))
 	log.Println(string(ColorGreen), "ϟ app - a package management assistant with super powers", string(ColorReset), version1) // can add + " & " + version2
 	TimeStamp(true)
-
 	NewLine()
 
+	// Check for new updates
+	url, tag := GetFileFromUrl("https://github.com/hkdb/app/releases/latest")
+	// no real release have been yet released
+	if tag == "releases" {
+		return
+	}
+	// already on latest release
+	if tag == version1 {
+		return
+	}
+
+	TimeStamp(false)
+	log.Println(string(ColorGreen), "A new version is available to download here:", string(ColorReset), url)
+	TimeStamp(true)
+	NewLine()
 }
 
 // Print error and exit
@@ -83,4 +97,3 @@ func PrintErrorMsg(eType string, e string) {
 	NewLine()
 
 }
-

--- a/utils/repo.go
+++ b/utils/repo.go
@@ -119,7 +119,7 @@ func GetNameFromUrl(g string) (string, string) {
 	if gArg == false {
 		PrintErrorMsgExit("Input Error:", "The gpg key should be in the form of a url...")
 	}
-	gFile := GetFileFromUrl(g)
+	_, gFile := GetFileFromUrl(g)
 	gExt := GetFileExtension(gFile)
 
 	return gExt, gFile
@@ -143,7 +143,7 @@ func GetRepoName(p, pType, g string) string {
 		if ws == true {
 			PrintErrorMsgExit("Error:", "URLs should not contain spaces...")
 		}
-		file := GetFileFromUrl(p)
+		_, file := GetFileFromUrl(p)
 		return file
 	default:
 		PrintErrorMsgExit("Error:", "Source format error")


### PR DESCRIPTION
Providing automatic release + binaries generation as #1 suggested (on push new tag).
Generates binaries for amd + arm for darwin + linux + windows.
Tested on my repo 🙂

Edit:
I did not include the `install.sh` script in the final archive.
Maybe something to add 🤔 or we should really merge it inside the `go` binary.