### PR TITLE
Github: add workflow support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags: '*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        os: [darwin, freebsd, linux, windows]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.4'
+
+      - name: Install dependencies
+        run: |
+          go mod download
+
+      - name: Build
+        run: |
+          GOARCH=${{ matrix.arch }} GOOS=${{ matrix.os }} go build -o app-${{ matrix.os }}-${{ matrix.arch }} ./main.go
+
+      # Tried gzip but without succeding of keeping execute permissions
+      - name: Zip
+        run: |
+          zip app-${{ matrix.os }}-${{ matrix.arch }}.zip app-${{ matrix.os }}-${{ matrix.arch }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: app-${{ matrix.os }}-${{ matrix.arch }}.zip
+          path: |
+            app-${{ matrix.os }}-${{ matrix.arch }}.zip
+          retention-days: 1
+
+  publish:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      # Must perform checkout first, since it deletes the target directory
+      # before running, and would therefore delete the downloaded artifacts
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+
+      - name: Publish release
+        run: |
+          TAG_NAME=${{ github.ref_name }}
+          gh release create $TAG_NAME --prerelease --title "$TAG_NAME" --target $GITHUB_SHA \
+            app-*/*


### PR DESCRIPTION
Providing automatic release + binaries generation as #1 suggested (on push new tag).
Generates binaries for amd + arm for darwin + linux + windows.
Tested on my repo 🙂

Edit:
I did not include the `install.sh` script in the final archive.
Maybe something to add 🤔 or we should really merge it inside the `go` binary.