### PR TITLE
Precommit add linter support

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,4 @@
+linters:
+  disable-all: true
+  enable:
+    - goimports

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/golangci/golangci-lint.git
+    rev: v1.59.0
+    hooks:
+      - id: golangci-lint-full

--- a/appimage/appimage.go
+++ b/appimage/appimage.go
@@ -1,12 +1,12 @@
 package appimage
 
 import (
-	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/db"
+	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/utils"
 
-	"os"
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -17,9 +17,9 @@ func Install(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == true {
-		utils.PrintErrorMsgExit(pkg + " is already installed...", "")
+		utils.PrintErrorMsgExit(pkg+" is already installed...", "")
 	}
 
 	name := installPkgs(pkg, false)
@@ -39,9 +39,9 @@ func Remove(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == false {
-		utils.PrintErrorMsgExit(pkg + " was not installed by app...", "")
+		utils.PrintErrorMsgExit(pkg+" was not installed by app...", "")
 	}
 
 	removePkg(pkg)
@@ -74,18 +74,18 @@ func ListSystem() {
 
 func ListSystemSearch(pkg string) {
 
-	fmt.Println("This action does not apply to AppImage...") 
-	
+	fmt.Println("This action does not apply to AppImage...")
+
 }
 
 func Update() {
 
-	fmt.Println("This action does not apply to AppImage...") 
+	fmt.Println("This action does not apply to AppImage...")
 
 }
 
 func Upgrade(pkg string) {
-	
+
 	fmt.Println("This action does not apply to AppImage... To upgrade an AppImage, simply remove the old and install the new...")
 
 }
@@ -98,7 +98,7 @@ func DistUpgrade() {
 
 func Search(pkg string) {
 
-	fmt.Println("This action does not apply to AppImage...") 
+	fmt.Println("This action does not apply to AppImage...")
 
 }
 
@@ -125,7 +125,7 @@ func History() {
 }
 
 func InstallAll() {
-	
+
 	// appimage
 	fmt.Println("AppImage:\n")
 	pkgs, fperr := db.ReadPkgSlice("", "packages", "appimage")
@@ -133,7 +133,7 @@ func InstallAll() {
 		utils.PrintErrorExit("AppImage - Read ERROR:", fperr)
 		os.Exit(1)
 	}
-	
+
 	for i := 1; i < len(pkgs); i++ {
 		fmt.Println(pkgs[i])
 		cpFile, err := db.ReadPkgs("packages/local", "appimage", pkgs[i])
@@ -153,4 +153,3 @@ func InstallAll() {
 	fmt.Println("\nAppImage Restore Completed...\n")
 
 }
-

--- a/arch/pacman.go
+++ b/arch/pacman.go
@@ -1,14 +1,14 @@
 package arch
 
 import (
-	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/db"
+	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/utils"
 
-	"syscall"
+	"fmt"
 	"os"
 	"os/exec"
-	"fmt"
+	"syscall"
 )
 
 var sudo = [3]string{"/usr/bin/sudo", "/bin/sh", "-c"}
@@ -21,12 +21,12 @@ func Install(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == true {
-		utils.PrintErrorMsgExit(pkg + " is already installed...", "")
+		utils.PrintErrorMsgExit(pkg+" is already installed...", "")
 	}
 
-	install := exec.Command(sudo[0], sudo[1], sudo[2], cmd + " -S " + pkg)
+	install := exec.Command(sudo[0], sudo[1], sudo[2], cmd+" -S "+pkg)
 	utils.RunCmd(install, "Installation Error:")
 
 	fmt.Println("\n Recording " + pkg + " to app history...\n")
@@ -44,12 +44,12 @@ func Remove(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == false {
-		utils.PrintErrorMsgExit(pkg + " was not installed by app...", "")
+		utils.PrintErrorMsgExit(pkg+" was not installed by app...", "")
 	}
 
-	remove := exec.Command(sudo[0], sudo[1], sudo[2], cmd + " -R " + pkg)
+	remove := exec.Command(sudo[0], sudo[1], sudo[2], cmd+" -R "+pkg)
 	utils.RunCmd(remove, "Remove Error:")
 
 	fmt.Println("\n Removing " + pkg + " from app history...\n")
@@ -68,23 +68,23 @@ func Purge(pkg string) {
 
 func AutoRemove() {
 
-	out, err := exec.Command("/bin/bash", "-c", cmd + " -Qtdq").Output()
+	out, err := exec.Command("/bin/bash", "-c", cmd+" -Qtdq").Output()
 	rmList := string(out)
-	if err != nil  && rmList != "" {
+	if err != nil && rmList != "" {
 		utils.PrintErrorExit("Read Auto Remove Package List Error:", err)
 	}
-	
+
 	if rmList == "" {
 		fmt.Println("No packages need to be automatically removed...\n")
 		os.Exit(1)
 	}
-	aRemove := exec.Command(sudo[0], sudo[1], sudo[2], "/usr/bin/pacman -Rns " + rmList)
+	aRemove := exec.Command(sudo[0], sudo[1], sudo[2], "/usr/bin/pacman -Rns "+rmList)
 	utils.RunCmd(aRemove, "Auto Remove Error:")
 
 }
 
 func ListSystem() {
-	
+
 	err := syscall.Exec("/usr/bin/pacman", []string{cmd, "-Q"}, os.Environ())
 	if err != nil {
 		utils.PrintErrorExit("List System Error:", err)
@@ -94,7 +94,7 @@ func ListSystem() {
 
 func ListSystemSearch(pkg string) {
 
-	listSys := exec.Command("/bin/sh", "-c", cmd + " -Q |grep " + pkg)
+	listSys := exec.Command("/bin/sh", "-c", cmd+" -Q |grep "+pkg)
 	utils.RunCmd(listSys, "List System Packages Error:")
 
 }
@@ -116,7 +116,7 @@ func Upgrade() {
 		upgrade := exec.Command("/usr/bin/garuda-update")
 		utils.RunCmd(upgrade, "Upgrade Error:")
 	default:
-		upgrade := exec.Command(sudo[0], sudo[1], sudo[2], cmd + " -Syyu")
+		upgrade := exec.Command(sudo[0], sudo[1], sudo[2], cmd+" -Syyu")
 		utils.RunCmd(upgrade, "Upgrade Error:")
 	}
 
@@ -138,7 +138,7 @@ func Search(pkg string) {
 }
 
 func InstallAll() {
-	
+
 	// pacman
 	fmt.Println("PACMAN:\n")
 	pkgs, aperr := db.ReadPkgs("", "packages", "pacman")
@@ -147,7 +147,7 @@ func InstallAll() {
 	}
 
 	command := cmd + " -S "
-	install := exec.Command(sudo[0], sudo[1], sudo[2], command + pkgs)
+	install := exec.Command(sudo[0], sudo[1], sudo[2], command+pkgs)
 	utils.RunCmd(install, "Installation Error:")
 
 }

--- a/arch/repo.go
+++ b/arch/repo.go
@@ -1,13 +1,13 @@
 package arch
 
 import (
+	"github.com/hkdb/app/db"
 	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/utils"
-	"github.com/hkdb/app/db"
-	
+
+	"fmt"
 	"os"
 	"os/exec"
-	"fmt"
 )
 
 func AddRepo(s, g string) {
@@ -42,7 +42,7 @@ func AddRepo(s, g string) {
 	runScript := exec.Command(sudo[0], sudo[1], sudo[2], sFull)
 	utils.RunCmd(runScript, "Script Error:")
 	utils.CreateDirIfNotExist(env.DBDir + "/packages/repo/local/pacman")
-	utils.Copy(sFull, env.DBDir + "/packages/repo/local/pacman/" + s)
+	utils.Copy(sFull, env.DBDir+"/packages/repo/local/pacman/"+s)
 	name := utils.GetFileName(s)
 
 	fmt.Println("\n" + name + " has been added...\n")
@@ -95,4 +95,3 @@ func RemoveRepo(s string) {
 	fmt.Println(repo + " has been removed...\n")
 
 }
-

--- a/arch/yay.go
+++ b/arch/yay.go
@@ -4,10 +4,10 @@ import (
 	"github.com/hkdb/app/db"
 	"github.com/hkdb/app/utils"
 
-	"syscall"
+	"fmt"
 	"os"
 	"os/exec"
-	"fmt"
+	"syscall"
 )
 
 var cmd_yay = "/usr/bin/yay"
@@ -19,9 +19,9 @@ func YayInstall(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == true {
-		utils.PrintErrorMsgExit(pkg + " is already installed...", "")
+		utils.PrintErrorMsgExit(pkg+" is already installed...", "")
 	}
 
 	install := exec.Command(cmd_yay, "-S", pkg)
@@ -42,15 +42,15 @@ func YayRemove(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == false {
-		utils.PrintErrorMsgExit(pkg + " was not installed by app...", "")
+		utils.PrintErrorMsgExit(pkg+" was not installed by app...", "")
 	}
 
 	remove := exec.Command(cmd_yay, "-R", pkg)
 	utils.RunCmd(remove, "Remove Error:")
 
-	fmt.Println("\n Removing " + pkg + " from app history...\n")	
+	fmt.Println("\n Removing " + pkg + " from app history...\n")
 	derr := db.RemovePkg("", "packages", "yay", pkg)
 	if derr != nil {
 		utils.PrintErrorExit("Delete Error: ", derr)
@@ -66,12 +66,12 @@ func YayPurge(pkg string) {
 
 func YayAutoRemove() {
 
-	out, err := exec.Command("/bin/bash", "-c", cmd_yay + " -Qtdq").Output()
+	out, err := exec.Command("/bin/bash", "-c", cmd_yay+" -Qtdq").Output()
 	rmList := string(out)
-	if err != nil  && rmList != "" {
+	if err != nil && rmList != "" {
 		utils.PrintErrorExit("Read Auto Remove Package List Error:", err)
 	}
-	
+
 	if rmList == "" {
 		fmt.Println("No packages need to be automatically removed...\n")
 		os.Exit(1)
@@ -82,7 +82,7 @@ func YayAutoRemove() {
 }
 
 func YayListSystem() {
-	
+
 	err := syscall.Exec(cmd_yay, []string{cmd_yay, "-Q"}, os.Environ())
 	if err != nil {
 		utils.PrintErrorExit("List System Error:", err)
@@ -92,7 +92,7 @@ func YayListSystem() {
 
 func YayListSystemSearch(pkg string) {
 
-	listSys := exec.Command("/bin/sh", "-c", cmd_yay + " -Q |grep " + pkg)
+	listSys := exec.Command("/bin/sh", "-c", cmd_yay+" -Q |grep "+pkg)
 	utils.RunCmd(listSys, "List Yay Packages Error:")
 
 }
@@ -127,7 +127,7 @@ func YaySearch(pkg string) {
 }
 
 func YayInstallAll() {
-	
+
 	// yay
 	fmt.Println("YAY:\n")
 	pkgs, aperr := db.ReadPkgs("", "packages", "yay")

--- a/cargo/cargo.go
+++ b/cargo/cargo.go
@@ -1,12 +1,12 @@
 package cargo
 
 import (
-	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/db"
+	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/utils"
 
-	"os/exec"
 	"fmt"
+	"os/exec"
 )
 
 var mgr = "cargo"
@@ -28,14 +28,14 @@ func Install(pkg, tag string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == true {
-		utils.PrintErrorMsgExit(p + " is already installed...", "")
+		utils.PrintErrorMsgExit(p+" is already installed...", "")
 	}
 
 	cmd := mgr + " install " + pkg
 	if isUrl == true {
-		cmd = mgr + " install --tag " + tag + " --git " + pkg 
+		cmd = mgr + " install --tag " + tag + " --git " + pkg
 	}
 	install := exec.Command(env.Bash, "-c", cmd)
 	utils.RunCmd(install, "Installation Error:")
@@ -63,9 +63,9 @@ func Remove(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == false {
-		utils.PrintErrorMsgExit(pkg + " was not installed by app...", "")
+		utils.PrintErrorMsgExit(pkg+" was not installed by app...", "")
 	}
 
 	remove := exec.Command(mgr, "uninstall", pkg)
@@ -93,14 +93,14 @@ func AutoRemove() {
 
 func ListSystem() {
 
-	list := exec.Command("ls", "-lah", env.HomeDir + "/.cargo/bin")
+	list := exec.Command("ls", "-lah", env.HomeDir+"/.cargo/bin")
 	utils.RunCmd(list, "List Package Error:")
 
 }
 
 func ListSystemSearch(pkg string) {
 
-	listSearch := exec.Command(env.Bash, "-c", "ls -lah " + "/.cargo/bin |grep " + pkg)
+	listSearch := exec.Command(env.Bash, "-c", "ls -lah "+"/.cargo/bin |grep "+pkg)
 	utils.RunCmd(listSearch, "List Package Search Error:")
 }
 
@@ -111,7 +111,7 @@ func Update() {
 }
 
 func Upgrade() {
-	
+
 	chkDep := exec.Command(env.Bash, "-c", "cargo --list |grep install-update")
 	err := utils.ChkIfCmdRuns(chkDep)
 	if err != nil {
@@ -142,7 +142,7 @@ func Search(pkg string) {
 }
 
 func InstallAll() {
-	
+
 	// cargo
 	fmt.Println("Cargo:\n")
 	pkgs, fperr := db.ReadPkgSlice("", "packages", mgr)
@@ -161,7 +161,7 @@ func InstallAll() {
 			if err != nil {
 				utils.PrintErrorExit("Cargo - Get Repo Data ERROR:", err)
 			}
-			install := exec.Command(env.Bash, "-c", mgr + " install --git " + url + " --tag " + tag)
+			install := exec.Command(env.Bash, "-c", mgr+" install --git "+url+" --tag "+tag)
 			utils.RunCmd(install, "Installation Error:")
 		} else {
 			install := exec.Command(mgr, "install", p)
@@ -172,4 +172,3 @@ func InstallAll() {
 	fmt.Println("Cargo Install All Completed...\n")
 
 }
-

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -9,13 +9,13 @@ import (
 	"os"
 )
 
-var m = flag.String("m", "", 
+var m = flag.String("m", "",
 	"Package Manager\n   usage: app -m <package manager> install neovim\n   default: auto-detect of native pkg manager <apt/dnf/pacman/pkg>\n   example: app install neovim\n   options:\n\t- apt\n\t- dnf\n\t- pacman\n\t- yay\n\t- pkg\n\t- flatpak\n\t- snap\n\t- brew\n\t- go\n\t- pip\n\t- cargo\n\t- appimage\n")
-var r = flag.String("r", "", 
+var r = flag.String("r", "",
 	"Restore / Install all on new system\n   usage: app -r <type>\n   option:\n\t- apt\n\t- dnf\n\t- pacman\n\t- pkg\n\t- yay\n\t- flatpak\n\t- snap\n\t- brew\n\t- go\n\t- pip\n\t- cargo\n\t- appimage\n\t- all\n")
-var y = flag.Bool("y", false, 
+var y = flag.Bool("y", false,
 	"Auto Yes - Skips the package manager confirmation (APT & DNF Only)\n   usage: app -y install neovim\n")
-var gpg = flag.String("gpg", "", 
+var gpg = flag.String("gpg", "",
 	"PGP Key URL - Used in combination with a url arg for add-repo (DNF Only)\n   usage: app -gpg <url> add-repo <url>\n")
 var c = flag.String("c", "",
 	"Channel - Used in combination with installing snap packages (SNAP Only)\n   usage: app -m snap -c <channel> install vlc\n   options:\n\t- beta\n\t- candidate\n\t- edge\n\t- stable\n")
@@ -36,13 +36,12 @@ func ParseFlags() env.Flags {
 		utils.PrintErrorMsgExit("Input Error:", "If you are trying to specify multiple packages, wrap the pacakges with single quotes....")
 	}
 
-
-	// If -r flag is empty, then it's not a restore and therefore, we are either 
+	// If -r flag is empty, then it's not a restore and therefore, we are either
 	// installing, upgrading, dist-upgrading, uninstalling, purging,  searching, or autoremoving
 	if *r == "" {
 		if a == "upgrade" && p == "all" && *m != "" {
-			fmt.Println(utils.ColorRed, 
-				"-m must not be specified when executing \"app upgrade all\"... Try", 
+			fmt.Println(utils.ColorRed,
+				"-m must not be specified when executing \"app upgrade all\"... Try",
 				utils.ColorYellow, "./app -h", utils.ColorRed, "to learn more...\n", utils.ColorReset)
 			os.Exit(1)
 		}
@@ -50,21 +49,21 @@ func ParseFlags() env.Flags {
 			*m = defaultPkgMgr()
 		}
 		if a == "" {
-			fmt.Println(utils.ColorRed, 
-				"Action must be specified unless you are restoring the system with -r... Try", 
+			fmt.Println(utils.ColorRed,
+				"Action must be specified unless you are restoring the system with -r... Try",
 				utils.ColorYellow, "./app -h", utils.ColorRed, "to learn more...\n", utils.ColorReset)
 			os.Exit(1)
 		}
-		if p == "" && a != "list" && a != "autoremove" && a != "update" && a != "history" && a != "upgrade" && a != "dist-upgrade" && a != "enable" && a != "disable" && a != "ls-repo"  && a != "settings"{
-			fmt.Println(utils.ColorRed, 
-				"Package(s) must be specified... Try", 
+		if p == "" && a != "list" && a != "autoremove" && a != "update" && a != "history" && a != "upgrade" && a != "dist-upgrade" && a != "enable" && a != "disable" && a != "ls-repo" && a != "settings" {
+			fmt.Println(utils.ColorRed,
+				"Package(s) must be specified... Try",
 				utils.ColorYellow, "./app -h", utils.ColorRed, "to learn more...\n", utils.ColorReset)
 			os.Exit(1)
 		}
 		if p != "" {
 			if a == "autoremove" || a == "update" || a == "settings" {
-				fmt.Println(utils.ColorRed, 
-					"Package(s) must not be specified for these actions... Try", 
+				fmt.Println(utils.ColorRed,
+					"Package(s) must not be specified for these actions... Try",
 					utils.ColorYellow, "./app -h", utils.ColorRed, "to learn more...\n", utils.ColorReset)
 				os.Exit(1)
 			}
@@ -81,32 +80,32 @@ func ParseFlags() env.Flags {
 		}
 	} else {
 		if *m != "" {
-			fmt.Println(utils.ColorRed, 
-				"-m (package manager) must not be specified when you are restoring the system with -r... Try", 
+			fmt.Println(utils.ColorRed,
+				"-m (package manager) must not be specified when you are restoring the system with -r... Try",
 				utils.ColorYellow, "./app -h", utils.ColorRed, "to learn more...\n", utils.ColorReset)
 			os.Exit(1)
 		}
 		if a != "" {
-			fmt.Println(utils.ColorRed, 
-				"-a (action) must not be specified when you are restoring the system with -r... Try", 
+			fmt.Println(utils.ColorRed,
+				"-a (action) must not be specified when you are restoring the system with -r... Try",
 				utils.ColorYellow, "./app -h", utils.ColorRed, "to learn more...\n", utils.ColorReset)
 			os.Exit(1)
 		}
 		if p != "" {
-			fmt.Println(utils.ColorRed, 
-				"-p (package(s)) must not be specified when you are restoring the system with -r... Try", 
+			fmt.Println(utils.ColorRed,
+				"-p (package(s)) must not be specified when you are restoring the system with -r... Try",
 				utils.ColorYellow, "./app -h", utils.ColorRed, "to learn more...\n", utils.ColorReset)
 			os.Exit(1)
 		}
 		if *c != "" {
-			fmt.Println(utils.ColorRed, 
-				"-c (channel) must not be specified when you are restoring the system with -r... Try", 
+			fmt.Println(utils.ColorRed,
+				"-c (channel) must not be specified when you are restoring the system with -r... Try",
 				utils.ColorYellow, "./app -h", utils.ColorRed, "to learn more...\n", utils.ColorReset)
 			os.Exit(1)
 		}
 		if *gpg != "" {
-			fmt.Println(utils.ColorRed, 
-				"-gpg (gpg key url) must not be specified when you are restoring the system with -r... Try", 
+			fmt.Println(utils.ColorRed,
+				"-gpg (gpg key url) must not be specified when you are restoring the system with -r... Try",
 				utils.ColorYellow, "./app -h", utils.ColorRed, "to learn more...\n", utils.ColorReset)
 			os.Exit(1)
 		}
@@ -116,7 +115,7 @@ func ParseFlags() env.Flags {
 		if *m != "apt" && *m != "dnf" {
 			if a != "install" && a != "remove" && a != "purge" && a != "upgrade" && a != "dist-upgrade" {
 				utils.PrintErrorMsgExit("Error: -y can only be used to install, remove, purge or upgrade...", "")
-			} 
+			}
 			utils.PrintErrorMsgExit("Error: -y can only be used with native package managers...", "")
 		}
 		env.AutoYes = true
@@ -129,7 +128,7 @@ func ParseFlags() env.Flags {
 		isUrl := utils.IsUrl(*gpg)
 		if isUrl == false {
 			utils.PrintErrorMsgExit("Error: -gpg can only a url as argument...", "")
-		} 
+		}
 	}
 
 	if *c != "" {
@@ -149,7 +148,7 @@ func ParseFlags() env.Flags {
 			utils.PrintErrorMsgExit("Error: The \"settings\" action can't be executed with any flags or options...", "")
 		}
 	}
-	
+
 	if *tag != "" {
 		if *m != "cargo" || a != "install" {
 			utils.PrintErrorMsgExit("Error: This flag is only available for installing git url with cargo...", "")
@@ -185,7 +184,7 @@ func usage() {
 }
 
 func defaultPkgMgr() string {
-	
+
 	switch env.OSType {
 	case "Linux":
 		switch env.Base {
@@ -212,4 +211,3 @@ func defaultPkgMgr() string {
 	return ""
 
 }
-

--- a/db/cargo_git.go
+++ b/db/cargo_git.go
@@ -24,12 +24,12 @@ func GitExists(pm, r string) (bool, error) {
 		}
 	}
 
-	return false, nil 
+	return false, nil
 
 }
 
 func RecordGit(pm, r string) error {
-	
+
 	current := ""
 
 	if _, err := os.Stat(env.DBDir + "/packages/repo/" + pm + ".json"); err == nil {
@@ -53,7 +53,7 @@ func RecordGit(pm, r string) error {
 	if werr != nil {
 		return werr
 	}
-	
+
 	return nil
 
 }
@@ -65,7 +65,7 @@ func RecordGitSetup(pm, name, u, t string) error {
 	if werr != nil {
 		return werr
 	}
-	
+
 	return nil
 
 }
@@ -84,7 +84,7 @@ func GetGitSetup(pm, name string) (string, string, error) {
 func RemoveGit(pm, p string) error {
 
 	rmRepos := strings.Split(p, " ")
-  
+
 	repos, err := ReadPkgSlice("packages", "repo", pm)
 	if err != nil {
 		return err
@@ -93,7 +93,7 @@ func RemoveGit(pm, p string) error {
 	// Remove matching elements from slice
 	for i := 0; i < len(rmRepos); i++ {
 		for x := 0; x < len(repos); x++ {
-      if rmRepos[i] == repos[x] {
+			if rmRepos[i] == repos[x] {
 				// Remove package git data
 				urlRec := env.DBDir + "/packages/repo/local/" + pm + "/" + p + ".json"
 				if _, err = os.Stat(urlRec); err == nil {
@@ -103,7 +103,7 @@ func RemoveGit(pm, p string) error {
 				}
 				repos = removeIndex(repos, x)
 			}
-		}	
+		}
 	}
 
 	// Join the new slice into string
@@ -138,7 +138,7 @@ func writeGitEntry(pm, n, u, t string) error {
 	// Write to DB
 	if err := pdb.Write(pm, n, repo); err != nil {
 		return err
-	}	
+	}
 
 	return nil
 
@@ -153,10 +153,9 @@ func readGitEntry(pm, name string) (Git, error) {
 		return repo, err
 	}
 	if err := pdb.Read(pm, name, &repo); err != nil {
-		return repo, err		
+		return repo, err
 	}
 
 	return repo, nil
 
 }
-

--- a/db/channels.go
+++ b/db/channels.go
@@ -11,7 +11,7 @@ func ChannelPreferred(pm, p string) bool {
 	if _, err := os.Stat(env.DBDir + "/packages/repo/channel/" + pm + "/" + p + ".json"); err == nil {
 		return true
 	}
-	return false 
+	return false
 
 }
 
@@ -22,7 +22,7 @@ func RecordChan(pm, name, c string) error {
 	if werr != nil {
 		return werr
 	}
-	
+
 	return nil
 
 }
@@ -44,7 +44,7 @@ func RemoveChan(pm, name string) error {
 	if err != nil {
 		return err
 	}
-	
+
 	return nil
 
 }
@@ -64,7 +64,7 @@ func writeChanEntry(pm, n, c string) error {
 	// Write to DB
 	if err := pdb.Write(pm, n, ch); err != nil {
 		return err
-	}	
+	}
 
 	return nil
 
@@ -79,7 +79,7 @@ func readChanEntry(pm, name string) (Channels, error) {
 		return ch, err
 	}
 	if err := pdb.Read(pm, name, &ch); err != nil {
-		return ch, err		
+		return ch, err
 	}
 
 	return ch, nil

--- a/db/classic.go
+++ b/db/classic.go
@@ -13,7 +13,7 @@ func RecordClassic(pm, pkg string, classic bool) error {
 	if werr != nil {
 		return werr
 	}
-	
+
 	return nil
 
 }
@@ -57,7 +57,7 @@ func writeClassicEntry(pm, n string, classic bool) error {
 	// Write to DB
 	if err := pdb.Write(pm, n, c); err != nil {
 		return err
-	}	
+	}
 
 	return nil
 
@@ -72,10 +72,9 @@ func readClassicEntry(pm, name string) (Classics, error) {
 		return classic, err
 	}
 	if err := pdb.Read(pm, name, &classic); err != nil {
-		return classic, err		
+		return classic, err
 	}
 
 	return classic, nil
 
 }
-

--- a/db/repo.go
+++ b/db/repo.go
@@ -24,12 +24,12 @@ func RepoExists(pm, r string) (bool, error) {
 		}
 	}
 
-	return false, nil 
+	return false, nil
 
 }
 
 func RecordRepo(pm, r string) error {
-	
+
 	current := ""
 
 	if _, err := os.Stat(env.DBDir + "/packages/repo/" + pm + ".json"); err == nil {
@@ -53,7 +53,7 @@ func RecordRepo(pm, r string) error {
 	if werr != nil {
 		return werr
 	}
-	
+
 	return nil
 
 }
@@ -65,7 +65,7 @@ func RecordSetup(pm, name, r, g string) error {
 	if werr != nil {
 		return werr
 	}
-	
+
 	return nil
 
 }
@@ -84,7 +84,7 @@ func GetSetup(pm, name string) (string, string, error) {
 func RemoveRepo(pm, rType, r string) error {
 
 	rmRepos := strings.Split(r, " ")
-  
+
 	repos, err := ReadPkgSlice("packages", "repo", pm)
 	if err != nil {
 		return err
@@ -93,7 +93,7 @@ func RemoveRepo(pm, rType, r string) error {
 	// Remove matching elements from slice
 	for i := 0; i < len(rmRepos); i++ {
 		for x := 0; x < len(repos); x++ {
-      if rmRepos[i] == repos[x] {
+			if rmRepos[i] == repos[x] {
 				if rType != "ppa" {
 					// Remove script
 					urlRec := env.DBDir + "/packages/repo/local/" + pm + "/" + r + ".json"
@@ -111,7 +111,7 @@ func RemoveRepo(pm, rType, r string) error {
 				}
 				repos = removeIndex(repos, x)
 			}
-		}	
+		}
 	}
 
 	// Join the new slice into string
@@ -146,7 +146,7 @@ func writeRepoEntry(pm, n, r, g string) error {
 	// Write to DB
 	if err := pdb.Write(pm, n, repo); err != nil {
 		return err
-	}	
+	}
 
 	return nil
 
@@ -161,10 +161,9 @@ func readRepoEntry(pm, name string) (Repos, error) {
 		return repo, err
 	}
 	if err := pdb.Read(pm, name, &repo); err != nil {
-		return repo, err		
+		return repo, err
 	}
 
 	return repo, nil
 
 }
-

--- a/db/types.go
+++ b/db/types.go
@@ -1,12 +1,12 @@
 package db
 
 type Packages struct {
-	Packages    string `json:"packages"`
+	Packages string `json:"packages"`
 }
 
 type Repos struct {
-	Repo	string `json:"repo"`
-	Gpg		string `json:"gpg"`
+	Repo string `json:"repo"`
+	Gpg  string `json:"gpg"`
 }
 
 type Classics struct {

--- a/debian/apt.go
+++ b/debian/apt.go
@@ -2,13 +2,13 @@ package debian
 
 import (
 	"github.com/hkdb/app/db"
-	"github.com/hkdb/app/utils"
 	"github.com/hkdb/app/env"
+	"github.com/hkdb/app/utils"
 
-	"syscall"
-	"os"
-  "os/exec"
 	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
 )
 
 var sudo = [3]string{"/usr/bin/sudo", "/bin/sh", "-c"}
@@ -21,9 +21,9 @@ func Install(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == true {
-		utils.PrintErrorMsgExit(pkg + " is already installed...", "")
+		utils.PrintErrorMsgExit(pkg+" is already installed...", "")
 	}
 
 	pname := pkg
@@ -39,7 +39,7 @@ func Install(pkg string) {
 		command = cmd + " -y" + action
 	}
 
-	install := exec.Command(sudo[0], sudo[1], sudo[2], command + pkg)
+	install := exec.Command(sudo[0], sudo[1], sudo[2], command+pkg)
 	utils.RunCmd(install, "Installation Error:")
 
 	fmt.Println("\n Recording " + pkg + " to app history...\n")
@@ -57,18 +57,18 @@ func Remove(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == false {
-		utils.PrintErrorMsgExit(pkg + " was not installed by app...", "")
+		utils.PrintErrorMsgExit(pkg+" was not installed by app...", "")
 	}
-	
+
 	action := " remove "
 	command := cmd + action
 	if env.AutoYes == true {
 		command = cmd + " -y" + action
 	}
 
-	remove := exec.Command(sudo[0], sudo[1], sudo[2], command + pkg)
+	remove := exec.Command(sudo[0], sudo[1], sudo[2], command+pkg)
 	utils.RunCmd(remove, "Remove Error:")
 
 	fmt.Println("\n Removing " + pkg + " from app history...\n")
@@ -81,14 +81,14 @@ func Remove(pkg string) {
 
 func Purge(pkg string) {
 
-  // Check if package is already installed
+	// Check if package is already installed
 	inst, ierr := db.IsInstalled("", "packages", "apt", pkg)
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == false {
-		utils.PrintErrorMsgExit(pkg + " was not installed by app...", "")
+		utils.PrintErrorMsgExit(pkg+" was not installed by app...", "")
 	}
 
 	action := " purge "
@@ -97,7 +97,7 @@ func Purge(pkg string) {
 		command = cmd + " -y" + action
 	}
 
-	purge := exec.Command(sudo[0], sudo[1], sudo[2], command + pkg)
+	purge := exec.Command(sudo[0], sudo[1], sudo[2], command+pkg)
 	utils.RunCmd(purge, "Purge Error:")
 
 	fmt.Println("\n Removing " + pkg + " from app history...\n")
@@ -124,7 +124,7 @@ func AutoRemove() {
 }
 
 func ListSystem() {
-	
+
 	err := syscall.Exec("/usr/bin/dpkg", []string{"/usr/bin/dpkg", "-l"}, os.Environ())
 	if err != nil {
 		utils.PrintErrorExit("List System Error:", err)
@@ -161,7 +161,7 @@ func Upgrade() {
 	if env.AutoYes == true {
 		command = cmd + " -y" + action
 	}
-	
+
 	upgrade := exec.Command(sudo[0], sudo[1], sudo[2], command)
 	utils.RunCmd(upgrade, "Upgrade Error:")
 
@@ -190,7 +190,7 @@ func Search(pkg string) {
 }
 
 func InstallAll() {
-	
+
 	// apt
 	fmt.Println("APT:\n")
 	pkgs, aperr := db.ReadPkgs("", "packages", "apt")
@@ -203,7 +203,7 @@ func InstallAll() {
 		command = cmd + " -y" + action
 	}
 
-	install := exec.Command(sudo[0], sudo[1], sudo[2], command + pkgs)
+	install := exec.Command(sudo[0], sudo[1], sudo[2], command+pkgs)
 	utils.RunCmd(install, "Installation Error:")
 
 }

--- a/debian/repo.go
+++ b/debian/repo.go
@@ -1,14 +1,14 @@
 package debian
 
 import (
+	"github.com/hkdb/app/db"
 	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/utils"
-	"github.com/hkdb/app/db"
-	
+
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
-	"fmt"
 )
 
 func AddRepo(s, g string) {
@@ -35,7 +35,7 @@ func AddRepo(s, g string) {
 
 	switch sType {
 	case "ppa":
-		cmd := exec.Command(sudo[0], sudo[1], sudo [2], "add-apt-repository " + s)
+		cmd := exec.Command(sudo[0], sudo[1], sudo[2], "add-apt-repository "+s)
 		utils.RunCmd(cmd, "Add Repo Error:")
 		name = s
 	case "sh":
@@ -56,7 +56,7 @@ func AddRepo(s, g string) {
 		runScript := exec.Command(sudo[0], sudo[1], sudo[2], sFull)
 		utils.RunCmd(runScript, "Script Error:")
 		utils.CreateDirIfNotExist(env.DBDir + "/packages/repo/local/apt")
-		utils.Copy(sFull, env.DBDir + "/packages/repo/local/apt/" + s)
+		utils.Copy(sFull, env.DBDir+"/packages/repo/local/apt/"+s)
 		name = utils.GetFileName(s)
 
 		fmt.Println("\nRepo added... Let's run update...\n")
@@ -89,13 +89,13 @@ func RemoveRepo(s string) {
 
 	switch sType {
 	case "ppa":
-		cmd := exec.Command(sudo[0], sudo[1], sudo [2], "add-apt-repository --remove " + s)
+		cmd := exec.Command(sudo[0], sudo[1], sudo[2], "add-apt-repository --remove "+s)
 		utils.RunCmd(cmd, "Remove Repo Error:")
 	default:
 		sources := strings.Split(s, " ")
 		for i := 0; i < len(sources); i++ {
 			fmt.Println("Removing /etc/apt/sources.list.d/" + sources[i] + ".list with sudo:")
-			rmRepo := exec.Command("/usr/bin/sudo", "/bin/bash", "-c", "rm /etc/apt/sources.list.d/" + sources[i] + ".list" )
+			rmRepo := exec.Command("/usr/bin/sudo", "/bin/bash", "-c", "rm /etc/apt/sources.list.d/"+sources[i]+".list")
 			utils.RunCmd(rmRepo, "Repo Remove Error:")
 		}
 	}
@@ -110,4 +110,3 @@ func RemoveRepo(s string) {
 	fmt.Println(s + " has been removed...\n")
 
 }
-

--- a/env/types.go
+++ b/env/types.go
@@ -1,15 +1,15 @@
 package env
 
 type Flags struct {
-	A string // Action
-	P string // Package or Other types of value for Action
-	M	string // Package Manager
-	R string // Restore
-	Y bool	 // Auto-Yes for certain package managers
-	G string // URL to GPG key for dnf/yum/rpm based distros when adding repo 
-	C string // Channel for specifying channel when install snaps
-	Classic bool // Classic confinement for snaps
-	Tag string // Tag (version) for installing git url with cargo 
+	A       string // Action
+	P       string // Package or Other types of value for Action
+	M       string // Package Manager
+	R       string // Restore
+	Y       bool   // Auto-Yes for certain package managers
+	G       string // URL to GPG key for dnf/yum/rpm based distros when adding repo
+	C       string // Channel for specifying channel when install snaps
+	Classic bool   // Classic confinement for snaps
+	Tag     string // Tag (version) for installing git url with cargo
 }
 
 var OSType string

--- a/flatpak/flatpak.go
+++ b/flatpak/flatpak.go
@@ -4,9 +4,9 @@ import (
 	"github.com/hkdb/app/db"
 	"github.com/hkdb/app/utils"
 
+	"fmt"
 	"os"
 	"os/exec"
-	"fmt"
 )
 
 var mgr = "flatpak"
@@ -18,9 +18,9 @@ func Install(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == true {
-		utils.PrintErrorMsgExit(pkg + " is already installed...", "")
+		utils.PrintErrorMsgExit(pkg+" is already installed...", "")
 	}
 
 	install := exec.Command(mgr, "install", pkg)
@@ -41,9 +41,9 @@ func Remove(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == false {
-		utils.PrintErrorMsgExit(pkg + " was not installed by app...", "")
+		utils.PrintErrorMsgExit(pkg+" was not installed by app...", "")
 	}
 
 	remove := exec.Command(mgr, "uninstall", pkg)
@@ -78,7 +78,7 @@ func ListSystem() {
 
 func ListSystemSearch(pkg string) {
 
-	listSearch := exec.Command("bash", "-c", mgr + " list |grep " + pkg)
+	listSearch := exec.Command("bash", "-c", mgr+" list |grep "+pkg)
 	utils.RunCmd(listSearch, "List Package Search Error:")
 }
 
@@ -110,7 +110,7 @@ func Search(pkg string) {
 }
 
 func InstallAll() {
-	
+
 	// flatpak
 	fmt.Println("Flatpak:\n")
 	pkgs, fperr := db.ReadPkgs("", "packages", "flatpak")
@@ -122,4 +122,3 @@ func InstallAll() {
 	utils.RunCmd(installAll, "Installation Error:")
 
 }
-

--- a/flatpak/repo.go
+++ b/flatpak/repo.go
@@ -1,13 +1,13 @@
 package flatpak
 
 import (
+	"github.com/hkdb/app/db"
 	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/utils"
-	"github.com/hkdb/app/db"
-	
+
+	"fmt"
 	"os/exec"
 	"strings"
-	"fmt"
 )
 
 func AddRepo(s, g string) {
@@ -77,4 +77,3 @@ func RemoveRepo(s string) {
 	fmt.Println(s + " has been removed...\n")
 
 }
-

--- a/freebsd/pkg.go
+++ b/freebsd/pkg.go
@@ -2,13 +2,13 @@ package freebsd
 
 import (
 	"github.com/hkdb/app/db"
-	"github.com/hkdb/app/utils"
 	"github.com/hkdb/app/env"
+	"github.com/hkdb/app/utils"
 
-	"syscall"
+	"fmt"
 	"os"
 	"os/exec"
-	"fmt"
+	"syscall"
 )
 
 var sudo = [3]string{"/usr/local/bin/sudo", "/bin/sh", "-c"}
@@ -23,9 +23,9 @@ func Install(pkg string) {
 	}
 
 	if inst == true {
-		utils.PrintErrorMsgExit(pkg + " is already installed...", "")
+		utils.PrintErrorMsgExit(pkg+" is already installed...", "")
 	}
-		
+
 	pname := pkg
 	local, name, pfile := utils.IsLocalInstall(pkg)
 	if local == true {
@@ -39,7 +39,7 @@ func Install(pkg string) {
 		command = cmd + " -y" + action
 	}
 
-	install := exec.Command(sudo[0], sudo[1], sudo[2], command + pkg)
+	install := exec.Command(sudo[0], sudo[1], sudo[2], command+pkg)
 	utils.RunCmd(install, "Installation Error:")
 
 	fmt.Println("\n Recording " + pkg + " to app history...\n")
@@ -57,18 +57,18 @@ func Remove(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == false {
-		utils.PrintErrorMsgExit(pkg + " was not installed by app...", "")
+		utils.PrintErrorMsgExit(pkg+" was not installed by app...", "")
 	}
-	
+
 	action := " remove "
 	command := cmd + action
 	if env.AutoYes == true {
 		command = cmd + " -y" + action
 	}
 
-	remove := exec.Command(sudo[0], sudo[1], sudo[2], command + pkg)
+	remove := exec.Command(sudo[0], sudo[1], sudo[2], command+pkg)
 	utils.RunCmd(remove, "Remove Error:")
 
 	fmt.Println("\n Removing " + pkg + " from app history...\n")
@@ -101,7 +101,7 @@ func AutoRemove() {
 }
 
 func ListSystem() {
-	
+
 	err := syscall.Exec(cmd, []string{cmd, "info"}, os.Environ())
 	if err != nil {
 		utils.PrintErrorExit("List System Error:", err)
@@ -129,11 +129,9 @@ func Update() {
 	update := exec.Command(sudo[0], sudo[1], sudo[2], command)
 	utils.RunCmd(update, "Update Error:")
 
-
 }
 
 func Upgrade() {
-
 
 	action := " upgrade"
 	command := cmd + action
@@ -162,7 +160,7 @@ func Search(pkg string) {
 }
 
 func InstallAll() {
-	
+
 	// apt
 	fmt.Println("PKG:\n")
 	pkgs, aperr := db.ReadPkgs("", "packages", "pkg")
@@ -175,8 +173,7 @@ func InstallAll() {
 		command = cmd + " -y" + action
 	}
 
-	install := exec.Command(sudo[0], sudo[1], sudo[2], command + pkgs)
+	install := exec.Command(sudo[0], sudo[1], sudo[2], command+pkgs)
 	utils.RunCmd(install, "Installation Error:")
 
 }
-

--- a/freebsd/repo.go
+++ b/freebsd/repo.go
@@ -15,4 +15,3 @@ func RemoveRepo(s string) {
 	fmt.Println("This is a Linux only command. Not supported in FreeBSD...")
 
 }
-

--- a/golang/golang.go
+++ b/golang/golang.go
@@ -1,13 +1,13 @@
 package golang
 
 import (
-	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/db"
+	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/utils"
 
+	"fmt"
 	"os"
 	"os/exec"
-	"fmt"
 )
 
 var mgr = "go"
@@ -19,9 +19,9 @@ func Install(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == true {
-		utils.PrintErrorMsgExit(pkg + " is already installed...", "")
+		utils.PrintErrorMsgExit(pkg+" is already installed...", "")
 	}
 
 	install := exec.Command(mgr, "install", pkg)
@@ -42,12 +42,12 @@ func Remove(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == false {
-		utils.PrintErrorMsgExit(pkg + " was not installed by app...", "")
+		utils.PrintErrorMsgExit(pkg+" was not installed by app...", "")
 	}
 
-	remove := exec.Command("rm", env.HomeDir + "/go/bin/" + pkg)
+	remove := exec.Command("rm", env.HomeDir+"/go/bin/"+pkg)
 	utils.RunCmd(remove, "Remove Error:")
 
 	fmt.Println("\n Removing " + pkg + " from app history...\n")
@@ -72,14 +72,14 @@ func AutoRemove() {
 
 func ListSystem() {
 
-	list := exec.Command("ls", "-lah", env.HomeDir + "/go/bin")
+	list := exec.Command("ls", "-lah", env.HomeDir+"/go/bin")
 	utils.RunCmd(list, "List Package Error:")
 
 }
 
 func ListSystemSearch(pkg string) {
 
-	listSearch := exec.Command("ls", "-lah", env.HomeDir + "/go/bin", "|", "grep", pkg)
+	listSearch := exec.Command("ls", "-lah", env.HomeDir+"/go/bin", "|", "grep", pkg)
 	utils.RunCmd(listSearch, "List Package Search Error:")
 }
 
@@ -120,7 +120,7 @@ func Search(pkg string) {
 }
 
 func InstallAll() {
-	
+
 	// go
 	fmt.Println("go:\n")
 	pkgs, fperr := db.ReadPkgs("", "packages", "go")
@@ -132,4 +132,3 @@ func InstallAll() {
 	utils.RunCmd(installAll, "Installation Error:")
 
 }
-

--- a/macos/brew.go
+++ b/macos/brew.go
@@ -4,9 +4,9 @@ import (
 	"github.com/hkdb/app/db"
 	"github.com/hkdb/app/utils"
 
+	"fmt"
 	"os"
 	"os/exec"
-	"fmt"
 )
 
 var mgr = "brew"
@@ -18,9 +18,9 @@ func Install(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == true {
-		utils.PrintErrorMsgExit(pkg + " is already installed...", "")
+		utils.PrintErrorMsgExit(pkg+" is already installed...", "")
 	}
 
 	install := exec.Command(mgr, "install", pkg)
@@ -41,9 +41,9 @@ func Remove(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == false {
-		utils.PrintErrorMsgExit(pkg + " was not installed by app...", "")
+		utils.PrintErrorMsgExit(pkg+" was not installed by app...", "")
 	}
 
 	remove := exec.Command(mgr, "uninstall", pkg)
@@ -110,7 +110,7 @@ func Search(pkg string) {
 }
 
 func InstallAll() {
-	
+
 	// brew
 	fmt.Println("Brew:\n")
 	pkgs, fperr := db.ReadPkgs("", "packages", "brew")
@@ -122,4 +122,3 @@ func InstallAll() {
 	utils.RunCmd(installAll, "Installation Error:")
 
 }
-

--- a/mgr/process.go
+++ b/mgr/process.go
@@ -1,21 +1,21 @@
 package mgr
 
 import (
-	"github.com/hkdb/app/env"
-	"github.com/hkdb/app/utils"
-	"github.com/hkdb/app/debian"
-	"github.com/hkdb/app/redhat"
-	"github.com/hkdb/app/arch"
-	"github.com/hkdb/app/freebsd"
-	"github.com/hkdb/app/flatpak"
-	"github.com/hkdb/app/snap"
-	brew "github.com/hkdb/app/macos"
-	"github.com/hkdb/app/golang"
-	"github.com/hkdb/app/pip"
-	"github.com/hkdb/app/cargo"
 	"github.com/hkdb/app/appimage"
+	"github.com/hkdb/app/arch"
+	"github.com/hkdb/app/cargo"
+	"github.com/hkdb/app/debian"
+	"github.com/hkdb/app/env"
+	"github.com/hkdb/app/flatpak"
+	"github.com/hkdb/app/freebsd"
+	"github.com/hkdb/app/golang"
+	brew "github.com/hkdb/app/macos"
+	"github.com/hkdb/app/pip"
+	"github.com/hkdb/app/redhat"
 	"github.com/hkdb/app/restore"
-	
+	"github.com/hkdb/app/snap"
+	"github.com/hkdb/app/utils"
+
 	"fmt"
 	"os"
 )
@@ -41,7 +41,7 @@ func Process(flag env.Flags) {
 		if a != "enable" && a != "disable" {
 			enabled := isEnabled(m)
 			if enabled == false {
-				utils.PrintErrorMsgExit(m + " has been disabled. You must first enable it before using it in app...\n", "")
+				utils.PrintErrorMsgExit(m+" has been disabled. You must first enable it before using it in app...\n", "")
 			}
 		}
 		execute(m, a, p, g, c, classic, tag)
@@ -70,7 +70,7 @@ func restoreAll() {
 				restore.RestoreAllRepos("pacman")
 				arch.InstallAll()
 				//fmt.Println("Arch Install All")
-			}	
+			}
 		}
 		if env.Base == "arch" && env.Yay == true {
 			fmt.Print("Restore all yay apps? (Y/n) ")
@@ -130,7 +130,7 @@ func restoreAll() {
 	default:
 		utils.PrintErrorMsgExit("OS not supported...", "")
 	}
-	
+
 	if env.Go == true {
 		fmt.Print("Restore all Go apps? (Y/n) ")
 		s := utils.Confirm()
@@ -189,7 +189,7 @@ func restoreOne(r string) {
 			}
 		case "yay":
 			if env.Yay == false {
-				utils.PrintErrorMsgExit(r + " is disabled... To enable it, run", "app -m " + r + " enable\n")
+				utils.PrintErrorMsgExit(r+" is disabled... To enable it, run", "app -m "+r+" enable\n")
 			}
 			npm := utils.GetNativePkgMgr()
 			if npm == "pacman" {
@@ -199,38 +199,38 @@ func restoreOne(r string) {
 			}
 		case "flatpak":
 			if env.Flatpak == false {
-				utils.PrintErrorMsgExit(r + " is disabled... To enable it, run", "app -m " + r + " enable\n")
+				utils.PrintErrorMsgExit(r+" is disabled... To enable it, run", "app -m "+r+" enable\n")
 			}
 			restore.RestoreAllRepos("flatpak")
 			flatpak.InstallAll()
 		case "snap":
 			if env.Snap == false {
-				utils.PrintErrorMsgExit(r + " is disabled... To enable it, run ", "app -m " + r + " enable\n")
+				utils.PrintErrorMsgExit(r+" is disabled... To enable it, run ", "app -m "+r+" enable\n")
 			}
 			snap.InstallAll()
 		case "appimage":
 			if env.AppImage == false {
-				utils.PrintErrorMsgExit(r + " is disabled... To enable it, run ", "app -m " + r + " enable\n")
+				utils.PrintErrorMsgExit(r+" is disabled... To enable it, run ", "app -m "+r+" enable\n")
 			}
 			appimage.InstallAll()
 		case "brew":
 			if env.Brew == false {
-				utils.PrintErrorMsgExit(r + " is disabled... To enable it, run ", "app -m " + r + " enable\n")
+				utils.PrintErrorMsgExit(r+" is disabled... To enable it, run ", "app -m "+r+" enable\n")
 			}
 			brew.InstallAll()
 		case "go":
 			if env.Go == false {
-				utils.PrintErrorMsgExit(r + " is disabled... To enable it, run ", "app -m " + r + " enable\n")
+				utils.PrintErrorMsgExit(r+" is disabled... To enable it, run ", "app -m "+r+" enable\n")
 			}
 			brew.InstallAll()
 		case "pip":
 			if env.Pip == false {
-				utils.PrintErrorMsgExit(r + " is disabled... To enable it, run ", "app -m " + r + " enable\n")
+				utils.PrintErrorMsgExit(r+" is disabled... To enable it, run ", "app -m "+r+" enable\n")
 			}
 			pip.InstallAll()
 		case "cargo":
 			if env.Cargo == false {
-				utils.PrintErrorMsgExit(r + " is disabled... To enable it, run ", "app -m " + r + " enable\n")
+				utils.PrintErrorMsgExit(r+" is disabled... To enable it, run ", "app -m "+r+" enable\n")
 			}
 			cargo.InstallAll()
 		case "scoop":
@@ -255,7 +255,7 @@ func restoreOne(r string) {
 }
 
 func execute(m, a, p, g, c string, classic bool, tag string) {
-	
+
 	if env.OSType == "Mac" && m != "brew" {
 		utils.PrintErrorMsgExit("Error:", "macOS currently only supports Homebrew...")
 	}
@@ -276,7 +276,7 @@ func execute(m, a, p, g, c string, classic bool, tag string) {
 		case "flatpak":
 			flatpak.Install(p)
 		case "snap":
-			snap.Install(p, c, classic)			
+			snap.Install(p, c, classic)
 		case "brew":
 			brew.Install(p)
 		case "go":
@@ -286,7 +286,7 @@ func execute(m, a, p, g, c string, classic bool, tag string) {
 		case "cargo":
 			cargo.Install(p, tag)
 		case "appimage":
-			appimage.Install(p)			
+			appimage.Install(p)
 		default:
 			fmt.Println("Unsupported package manager... Exiting...\n")
 			os.Exit(1)
@@ -316,7 +316,7 @@ func execute(m, a, p, g, c string, classic bool, tag string) {
 		case "cargo":
 			cargo.Remove(p)
 		case "appimage":
-			appimage.Remove(p)			
+			appimage.Remove(p)
 		default:
 			fmt.Println("Unsupported package manager... Exiting...\n")
 			os.Exit(1)
@@ -628,7 +628,7 @@ func execute(m, a, p, g, c string, classic bool, tag string) {
 				debian.ListSystem()
 			} else {
 				debian.ListSystemSearch(p)
-			}	
+			}
 		case "dnf":
 			if p == "" {
 				redhat.ListSystem()

--- a/pip/pip.go
+++ b/pip/pip.go
@@ -1,13 +1,13 @@
 package pip
 
 import (
-	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/db"
+	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/utils"
 
+	"fmt"
 	"os"
 	"os/exec"
-	"fmt"
 )
 
 var mgr = "pip"
@@ -19,9 +19,9 @@ func Install(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == true {
-		utils.PrintErrorMsgExit(pkg + " is already installed...", "")
+		utils.PrintErrorMsgExit(pkg+" is already installed...", "")
 	}
 
 	install := exec.Command(mgr, "install", pkg)
@@ -42,9 +42,9 @@ func Remove(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == false {
-		utils.PrintErrorMsgExit(pkg + " was not installed by app...", "")
+		utils.PrintErrorMsgExit(pkg+" was not installed by app...", "")
 	}
 
 	remove := exec.Command(mgr, "uninstall", pkg)
@@ -79,7 +79,7 @@ func ListSystem() {
 
 func ListSystemSearch(pkg string) {
 
-	listSearch := exec.Command(env.Bash, "-c", mgr + " list |grep " + pkg)
+	listSearch := exec.Command(env.Bash, "-c", mgr+" list |grep "+pkg)
 	utils.RunCmd(listSearch, "List Package Search Error:")
 }
 
@@ -120,7 +120,7 @@ func Search(pkg string) {
 }
 
 func InstallAll() {
-	
+
 	// pip
 	fmt.Println("Pip:\n")
 	pkgs, fperr := db.ReadPkgs("", "packages", mgr)
@@ -132,4 +132,3 @@ func InstallAll() {
 	utils.RunCmd(installAll, "Installation Error:")
 
 }
-

--- a/redhat/dnf.go
+++ b/redhat/dnf.go
@@ -2,13 +2,13 @@ package redhat
 
 import (
 	"github.com/hkdb/app/db"
-	"github.com/hkdb/app/utils"
 	"github.com/hkdb/app/env"
+	"github.com/hkdb/app/utils"
 
-	"syscall"
+	"fmt"
 	"os"
 	"os/exec"
-	"fmt"
+	"syscall"
 )
 
 var sudo = [3]string{"/usr/bin/sudo", "/bin/sh", "-c"}
@@ -23,9 +23,9 @@ func Install(pkg string) {
 	}
 
 	if inst == true {
-		utils.PrintErrorMsgExit(pkg + " is already installed...", "")
+		utils.PrintErrorMsgExit(pkg+" is already installed...", "")
 	}
-		
+
 	pname := pkg
 	local, name, pfile := utils.IsLocalInstall(pkg)
 	if local == true {
@@ -39,7 +39,7 @@ func Install(pkg string) {
 		command = cmd + " -y" + action
 	}
 
-	install := exec.Command(sudo[0], sudo[1], sudo[2], command + pkg)
+	install := exec.Command(sudo[0], sudo[1], sudo[2], command+pkg)
 	utils.RunCmd(install, "Installation Error:")
 
 	fmt.Println("\n Recording " + pkg + " to app history...\n")
@@ -57,18 +57,18 @@ func Remove(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == false {
-		utils.PrintErrorMsgExit(pkg + " was not installed by app...", "")
+		utils.PrintErrorMsgExit(pkg+" was not installed by app...", "")
 	}
-	
+
 	action := " remove "
 	command := cmd + action
 	if env.AutoYes == true {
 		command = cmd + " -y" + action
 	}
 
-	remove := exec.Command(sudo[0], sudo[1], sudo[2], command + pkg)
+	remove := exec.Command(sudo[0], sudo[1], sudo[2], command+pkg)
 	utils.RunCmd(remove, "Remove Error:")
 
 	fmt.Println("\n Removing " + pkg + " from app history...\n")
@@ -101,7 +101,7 @@ func AutoRemove() {
 }
 
 func ListSystem() {
-	
+
 	err := syscall.Exec("/usr/bin/rpm", []string{"/usr/bin/rpm", "-qa"}, os.Environ())
 	if err != nil {
 		utils.PrintErrorExit("List System Error:", err)
@@ -133,7 +133,6 @@ func Update() {
 
 func Upgrade() {
 
-
 	action := " upgrade"
 	command := cmd + action
 	if env.AutoYes == true {
@@ -161,7 +160,7 @@ func Search(pkg string) {
 }
 
 func InstallAll() {
-	
+
 	// apt
 	fmt.Println("DNF:\n")
 	pkgs, aperr := db.ReadPkgs("", "packages", "dnf")
@@ -174,8 +173,7 @@ func InstallAll() {
 		command = cmd + " -y" + action
 	}
 
-	install := exec.Command(sudo[0], sudo[1], sudo[2], command + pkgs)
+	install := exec.Command(sudo[0], sudo[1], sudo[2], command+pkgs)
 	utils.RunCmd(install, "Installation Error:")
 
 }
-

--- a/redhat/repo.go
+++ b/redhat/repo.go
@@ -1,14 +1,14 @@
 package redhat
 
 import (
+	"github.com/hkdb/app/db"
 	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/utils"
-	"github.com/hkdb/app/db"
-	
+
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
-	"fmt"
 )
 
 func AddRepo(s, g string) {
@@ -39,9 +39,9 @@ func AddRepo(s, g string) {
 			utils.PrintErrorMsgExit("Input Error:", "No gpg url was specified...")
 		}
 		_, sFile := utils.GetNameFromUrl(s)
-		gpg := exec.Command(sudo[0], sudo[1], sudo[2], "/usr/bin/rpm --import " + g)
+		gpg := exec.Command(sudo[0], sudo[1], sudo[2], "/usr/bin/rpm --import "+g)
 		utils.RunCmd(gpg, "Import PGP Key Error:")
-		cmd := exec.Command(sudo[0], sudo[1], sudo [2], "dnf config-manager --add-repo " + s)
+		cmd := exec.Command(sudo[0], sudo[1], sudo[2], "dnf config-manager --add-repo "+s)
 		utils.RunCmd(cmd, "Add Repo Error:")
 		name = sFile
 		db.RecordSetup("dnf", name, s, g)
@@ -58,7 +58,7 @@ func AddRepo(s, g string) {
 		runScript := exec.Command(sudo[0], sudo[1], sudo[2], sFull)
 		utils.RunCmd(runScript, "Script Error:")
 		utils.CreateDirIfNotExist(env.DBDir + "/packages/repo/local/dnf")
-		utils.Copy(sFull, env.DBDir + "/packages/repo/local/dnf/" + s)
+		utils.Copy(sFull, env.DBDir+"/packages/repo/local/dnf/"+s)
 		name = utils.GetFileName(s)
 	default:
 		utils.PrintErrorMsgExit("Repo Source Error:", "This is not a supported type of repo source...")
@@ -88,7 +88,7 @@ func RemoveRepo(s string) {
 	sources := strings.Split(s, " ")
 	for i := 0; i < len(sources); i++ {
 		fmt.Println("Removing /etc/yum.repos.d/" + sources[i] + " with sudo:")
-		rmRepo := exec.Command("/usr/bin/sudo", "/bin/bash", "-c", "rm /etc/yum.repos.d/" + sources[i] )
+		rmRepo := exec.Command("/usr/bin/sudo", "/bin/bash", "-c", "rm /etc/yum.repos.d/"+sources[i])
 		utils.RunCmd(rmRepo, "Repo Remove Error:")
 	}
 
@@ -102,4 +102,3 @@ func RemoveRepo(s string) {
 	fmt.Println(s + " has been removed...\n")
 
 }
-

--- a/restore/repo.go
+++ b/restore/repo.go
@@ -1,31 +1,32 @@
 package restore
 
 import (
-	"github.com/hkdb/app/env"
-	"github.com/hkdb/app/utils"
+	"github.com/hkdb/app/arch"
 	"github.com/hkdb/app/db"
 	"github.com/hkdb/app/debian"
-	"github.com/hkdb/app/redhat"
-	"github.com/hkdb/app/arch"
+	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/flatpak"
+	"github.com/hkdb/app/redhat"
+	"github.com/hkdb/app/utils"
 
 	"fmt"
 	"os"
 )
+
 func RestoreAllRepos(pm string) {
-	
+
 	pmrDir := env.DBDir + "/packages/repo/" + pm + ".json"
 	if _, err := os.Stat(pmrDir); os.IsNotExist(err) {
-			fmt.Println("There are no repos added by app... Moving on...")
-			return
+		fmt.Println("There are no repos added by app... Moving on...")
+		return
 	}
 
 	repos, err := db.ReadPkgSlice("packages", "repo", pm)
 	if err != nil {
 		utils.PrintErrorExit("Read Repo List Error:", err)
 	}
-	
-	for i := 0; i < len(repos); i++ {	
+
+	for i := 0; i < len(repos); i++ {
 		name := repos[i]
 		rType := utils.GetRepoRestoreType(pm, repos[i])
 		switch pm {
@@ -34,7 +35,7 @@ func RestoreAllRepos(pm string) {
 			case "ppa":
 				debian.AddRepo(name, "")
 			case "sh":
-				debian.AddRepo(env.DBDir + "/packages/repos/local/" + pm + "/" + name + ".sh", "")
+				debian.AddRepo(env.DBDir+"/packages/repos/local/"+pm+"/"+name+".sh", "")
 			case "json":
 				utils.PrintErrorMsgExit("Url/Gpg repo records are not supported for Debian based distros...", "")
 			default:
@@ -43,7 +44,7 @@ func RestoreAllRepos(pm string) {
 		case "dnf":
 			switch rType {
 			case "sh":
-				redhat.AddRepo(env.DBDir + "/packages/repos/local/" + pm + "/" + name + ".sh", "")
+				redhat.AddRepo(env.DBDir+"/packages/repos/local/"+pm+"/"+name+".sh", "")
 			case "json":
 				r, g, err := db.GetSetup(pm, repos[i])
 				if err != nil {
@@ -56,7 +57,7 @@ func RestoreAllRepos(pm string) {
 		case "pacman":
 			switch rType {
 			case "sh":
-				arch.AddRepo(env.DBDir + "/packages/repos/local/" + pm + "/" + name + ".sh", "")
+				arch.AddRepo(env.DBDir+"/packages/repos/local/"+pm+"/"+name+".sh", "")
 			default:
 				utils.PrintErrorMsgExit("Repo Records Error:", "Unrecognized record type for Arch based distros...")
 			}
@@ -79,4 +80,3 @@ func RestoreAllRepos(pm string) {
 	}
 
 }
-

--- a/snap/snap.go
+++ b/snap/snap.go
@@ -1,14 +1,14 @@
 package snap
 
 import (
-	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/db"
+	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/utils"
 
-	"syscall"
+	"fmt"
 	"os"
 	"os/exec"
-	"fmt"
+	"syscall"
 )
 
 var sudo = [3]string{"/usr/bin/sudo", "/bin/sh", "-c"}
@@ -21,25 +21,25 @@ func Install(pkg, c string, classic bool) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == true {
-		utils.PrintErrorMsgExit(pkg + " has already been installed...", "")
+		utils.PrintErrorMsgExit(pkg+" has already been installed...", "")
 	}
 
 	cmd := "install "
 	end := ""
 	if c != "" {
 		switch c {
-			case "edge", "stable", "candidate", "beta":
-				cmd = cmd + "--channel=" + c + " "
-			default:
-				utils.PrintErrorMsgExit("Input Error:", "Not a valid channel for snap...")
+		case "edge", "stable", "candidate", "beta":
+			cmd = cmd + "--channel=" + c + " "
+		default:
+			utils.PrintErrorMsgExit("Input Error:", "Not a valid channel for snap...")
 		}
 	}
 	if classic == true {
 		end = " --classic"
 	}
-	install := exec.Command(sudo[0], sudo[1], sudo[2], "/usr/bin/snap " + cmd + pkg + end)
+	install := exec.Command(sudo[0], sudo[1], sudo[2], "/usr/bin/snap "+cmd+pkg+end)
 	utils.RunCmd(install, "Installation Error:")
 
 	fmt.Println("\n Recording " + pkg + " to app history...\n")
@@ -67,12 +67,12 @@ func Remove(pkg string) {
 	if ierr != nil {
 		utils.PrintErrorExit("Install Check Error:", ierr)
 	}
-	
+
 	if inst == false {
-		utils.PrintErrorMsgExit(pkg + " was not installed by app...", "")
+		utils.PrintErrorMsgExit(pkg+" was not installed by app...", "")
 	}
 
-	remove := exec.Command(sudo[0], sudo[1], sudo[2], "/usr/bin/snap remove " + pkg)
+	remove := exec.Command(sudo[0], sudo[1], sudo[2], "/usr/bin/snap remove "+pkg)
 	utils.RunCmd(remove, "Remove Error:")
 
 	fmt.Println("\n Removing " + pkg + " from app history...\n")
@@ -109,7 +109,7 @@ func AutoRemove() {
 }
 
 func ListSystem() {
-	
+
 	err := syscall.Exec(mgr, []string{mgr, "list"}, os.Environ())
 	if err != nil {
 		utils.PrintErrorExit("List System Error:", err)
@@ -158,8 +158,8 @@ func Search(pkg string) {
 }
 
 func InstallAll() {
-	
-	// snap	
+
+	// snap
 	action := " install "
 
 	fmt.Println("Snap:\n")
@@ -169,9 +169,9 @@ func InstallAll() {
 		pkgs, sperr := db.ReadPkgs("", "packages", "snap")
 		if sperr != nil {
 			utils.PrintErrorExit("Snap - Read ERROR:", sperr)
-		} 
+		}
 		classic := ""
-		isClassic, icerr := db.GetClassic("snap", pkgs) 
+		isClassic, icerr := db.GetClassic("snap", pkgs)
 		if icerr != nil {
 			utils.PrintErrorExit("Snap - Confinement Preference Read Error:", icerr)
 		}
@@ -179,7 +179,7 @@ func InstallAll() {
 		if isClassic == true {
 			classic = " --classic"
 		}
-		install := exec.Command(sudo[0], sudo[1], sudo[2], command + " " + pkgs + classic)
+		install := exec.Command(sudo[0], sudo[1], sudo[2], command+" "+pkgs+classic)
 		utils.RunCmd(install, "Installation Error:")
 	} else {
 		pkgs, sperr := db.ReadPkgSlice("", "packages", "snap")
@@ -196,7 +196,7 @@ func InstallAll() {
 				}
 				command = command + " --channel=" + ch
 			}
-			
+
 			classic := ""
 			isClassic, err := db.GetClassic("snap", pkgs[i])
 			if err != nil {
@@ -206,11 +206,10 @@ func InstallAll() {
 			if isClassic == true {
 				classic = " --classic"
 			}
-		
-			install := exec.Command(sudo[0], sudo[1], sudo[2], command + " " + pkgs[i] + classic)
+
+			install := exec.Command(sudo[0], sudo[1], sudo[2], command+" "+pkgs[i]+classic)
 			utils.RunCmd(install, "Installation Error:")
 		}
 	}
 
 }
-

--- a/utils/cmd.go
+++ b/utils/cmd.go
@@ -1,9 +1,9 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
-	"fmt"
 )
 
 func RunCmd(c *exec.Cmd, msg string) {
@@ -14,15 +14,15 @@ func RunCmd(c *exec.Cmd, msg string) {
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
 	if err := cmd.Run(); err != nil {
-    PrintErrorExit(msg, err)
-  }
+		PrintErrorExit(msg, err)
+	}
 
 	fmt.Println()
 
 }
 
 func RunCmdQuiet(c *exec.Cmd, msg string) {
-	
+
 	cmd := c
 	if err := cmd.Run(); err != nil {
 		PrintErrorExit(msg, err)

--- a/utils/files.go
+++ b/utils/files.go
@@ -4,14 +4,14 @@ import (
 	"github.com/hkdb/app/db"
 	"github.com/hkdb/app/env"
 
-	"os"
-	"os/exec"
-	"strings"
+	"bufio"
 	"errors"
 	"io"
 	"io/ioutil"
+	"os"
+	"os/exec"
 	"path/filepath"
-	"bufio"
+	"strings"
 )
 
 func IsLocalInstall(filename string) (bool, string, string) {
@@ -19,8 +19,8 @@ func IsLocalInstall(filename string) (bool, string, string) {
 	// Get the extension of the file
 	ext := GetFileExtension(filename)
 	if ext == "NONE" {
-      return false, "", ""  //if no extension is present print failure
-  }
+		return false, "", "" //if no extension is present print failure
+	}
 
 	// Check extension against current environment
 	switch env.Base {
@@ -37,25 +37,25 @@ func IsLocalInstall(filename string) (bool, string, string) {
 	}
 
 	// Get working path
-	path := GetWorkPath() 
-  // fmt.Println("Working Path:", path)
+	path := GetWorkPath()
+	// fmt.Println("Working Path:", path)
 
 	// Check if config dir for local package exists. If it doesn't, mkdir
 	dir := env.DBDir + "/packages/local/" + ext
 	if _, derr := os.Stat(dir); os.IsNotExist(derr) {
-    merr := os.MkdirAll(dir, os.ModePerm)
+		merr := os.MkdirAll(dir, os.ModePerm)
 		if merr != nil {
 			PrintErrorExit("Error:", merr)
 		}
 	}
 
-  // fmt.Println("DB Dir:", dir)
+	// fmt.Println("DB Dir:", dir)
 
 	// Set source package file
 	srcpkg := path + "/" + filename
-  destpkg := dir + "/" + filename
+	destpkg := dir + "/" + filename
 
-  //fmt.Println("Copying package from " + srcpkg + " to " + destpkg + "...")
+	//fmt.Println("Copying package from " + srcpkg + " to " + destpkg + "...")
 
 	// Copy local package to config dir
 	cerr := Copy(srcpkg, destpkg)
@@ -81,14 +81,14 @@ func IsLocalInstall(filename string) (bool, string, string) {
 
 	pname := strings.TrimSuffix(string(pNameCmd), "\n")
 
-  // fmt.Println("Package Name:", pname)
+	// fmt.Println("Package Name:", pname)
 
 	// Mark package as local
-	rerr := db.RecordPkg("", "packages" , ext, pname)
+	rerr := db.RecordPkg("", "packages", ext, pname)
 	if rerr != nil {
 		PrintErrorExit("Record Local Package Error: ", rerr)
 	}
-	
+
 	// Record package and file name association
 	rferr := db.RecordPkg("packages/local", ext, pname, filename)
 	if rferr != nil {
@@ -96,11 +96,11 @@ func IsLocalInstall(filename string) (bool, string, string) {
 	}
 
 	return true, pname, srcpkg
-	
+
 }
 
 func Copy(src, dst string) error {
-	
+
 	sourceFileStat, err := os.Stat(src)
 	if err != nil {
 		return err
@@ -130,7 +130,7 @@ func Copy(src, dst string) error {
 func CreateDirIfNotExist(dir string) {
 
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-    err = os.MkdirAll(dir, os.ModePerm)
+		err = os.MkdirAll(dir, os.ModePerm)
 		if err != nil {
 			PrintErrorExit("Error:", err)
 		}
@@ -139,7 +139,7 @@ func CreateDirIfNotExist(dir string) {
 }
 
 func DeleteDirIfEmpty(dir string) {
-	
+
 	// Clean-up dir
 	if empty, _ := DirIsEmpty(dir); empty == true {
 		if err := os.Remove(dir); err != nil {
@@ -150,18 +150,18 @@ func DeleteDirIfEmpty(dir string) {
 }
 
 func DirIsEmpty(dir string) (bool, error) {
-  
-	f, err := os.Open(dir)
-  if err != nil {
-    return false, err
-  }
-  defer f.Close()
 
-  _, err = f.Readdirnames(1) // Or f.Readdir(1)
-  if err == io.EOF {
-    return true, nil
-  }
-  return false, err
+	f, err := os.Open(dir)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1) // Or f.Readdir(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err
 
 }
 
@@ -172,7 +172,7 @@ func GetWorkPath() string {
 	if err != nil {
 		PrintErrorExit("Path Read Error:", err)
 	}
-	
+
 	return path
 
 }
@@ -182,20 +182,19 @@ func GetFileExtension(filename string) string {
 	// Get the extension of the file
 	extIndex := strings.LastIndex(filename, ".")
 	if extIndex == -1 {
-      return "NONE" 
-  }
+		return "NONE"
+	}
 
 	ext := filename[extIndex+1:]
-	
+
 	return ext
 
 }
 
-
 func GetFileName(filename string) string {
 
 	var ext = filepath.Ext(filename)
-	var name = filename[0:len(filename)-len(ext)]
+	var name = filename[0 : len(filename)-len(ext)]
 
 	return name
 
@@ -270,7 +269,7 @@ func WriteDotDesktop(pkg, icon, file, dest, share string) {
 
 func EditSettings(lType, value string) {
 
-	input, err := ioutil.ReadFile(env.DBDir + "/settings.conf" )
+	input, err := ioutil.ReadFile(env.DBDir + "/settings.conf")
 	if err != nil {
 		PrintErrorExit("Read settings Error:", err)
 	}
@@ -284,7 +283,7 @@ func EditSettings(lType, value string) {
 	}
 
 	output := strings.Join(lines, "\n")
-	err = ioutil.WriteFile(env.DBDir + "/settings.conf", []byte(output), 0644)
+	err = ioutil.WriteFile(env.DBDir+"/settings.conf", []byte(output), 0644)
 	if err != nil {
 		PrintErrorExit("Write settings Error:", err)
 	}
@@ -293,7 +292,7 @@ func EditSettings(lType, value string) {
 
 func ReadDotDesktop(file string) (*DotDesktop, error) {
 
-  dd := &DotDesktop{}
+	dd := &DotDesktop{}
 	f, err := os.Open(file)
 	if err != nil {
 		return dd, err
@@ -301,25 +300,25 @@ func ReadDotDesktop(file string) (*DotDesktop, error) {
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
-	
+
 	for scanner.Scan() {
-    line := scanner.Text()
-    entry := strings.Split(line, "=")
-    if len(entry) > 2 {
-      PrintErrorMsgExit("Read .desktop Error:", "Malformed .desktop file...")
-    }
-    if entry[0] == "Name" {
-      dd.Name = entry[1]
-      if dd.Icon != "" {
-        break
-      }
-    }
-    if entry[0] == "Icon" {
-      dd.Icon = entry[1]
-      if dd.Name != "" {
-        break
-      }
-    }
+		line := scanner.Text()
+		entry := strings.Split(line, "=")
+		if len(entry) > 2 {
+			PrintErrorMsgExit("Read .desktop Error:", "Malformed .desktop file...")
+		}
+		if entry[0] == "Name" {
+			dd.Name = entry[1]
+			if dd.Icon != "" {
+				break
+			}
+		}
+		if entry[0] == "Icon" {
+			dd.Icon = entry[1]
+			if dd.Name != "" {
+				break
+			}
+		}
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -331,8 +330,8 @@ func ReadDotDesktop(file string) (*DotDesktop, error) {
 }
 
 func ReadFileLine(file string, line int) (string, error) {
-	
-	line = line-1 
+
+	line = line - 1
 
 	f, err := os.Open(file)
 	if err != nil {
@@ -389,7 +388,6 @@ func RemoveDirRecursive(dir string) {
 	}
 
 }
-
 
 func RemoveFile(file string) {
 

--- a/utils/files_types.go
+++ b/utils/files_types.go
@@ -1,6 +1,6 @@
 package utils
 
 type DotDesktop struct {
-  Name string
-  Icon string
+	Name string
+	Icon string
 }

--- a/utils/generator.go
+++ b/utils/generator.go
@@ -2,8 +2,8 @@ package utils
 
 import (
 	"crypto/rand"
-	"io"
 	"encoding/base64"
+	"io"
 )
 
 // Function to generate a random string
@@ -14,4 +14,3 @@ func RandString(nByte int) (string, error) {
 	}
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
-

--- a/utils/http.go
+++ b/utils/http.go
@@ -7,9 +7,9 @@ import (
 
 func GetFileFromUrl(url string) string {
 
-		r,_ := http.NewRequest("GET", url, nil)
-		file := path.Base(r.URL.Path)
+	r, _ := http.NewRequest("GET", url, nil)
+	file := path.Base(r.URL.Path)
 
-		return file
+	return file
 
 }

--- a/utils/input.go
+++ b/utils/input.go
@@ -44,10 +44,8 @@ func containsString(slice []string, element string) bool {
 }
 
 func HasWhiteSpace(input string) bool {
-	
+
 	ws := regexp.MustCompile(`\s`).MatchString(input)
 	return ws
 
 }
-
-

--- a/utils/output.go
+++ b/utils/output.go
@@ -1,8 +1,8 @@
 package utils
 
 import (
-	"log"
 	"fmt"
+	"log"
 	"os"
 )
 
@@ -83,4 +83,3 @@ func PrintErrorMsg(eType string, e string) {
 	NewLine()
 
 }
-

--- a/utils/packages.go
+++ b/utils/packages.go
@@ -2,14 +2,14 @@ package utils
 
 import (
 	"github.com/hkdb/app/db"
-	
+
 	"fmt"
 	"strings"
 )
 
 func History(pm, p string) {
 
-	pkgs, err := db.ReadPkgSlice("","packages", pm)
+	pkgs, err := db.ReadPkgSlice("", "packages", pm)
 	if err != nil {
 		PrintErrorExit("Read History Error:", err)
 	}

--- a/utils/repo.go
+++ b/utils/repo.go
@@ -1,17 +1,17 @@
 package utils
 
 import (
-	"github.com/hkdb/app/env"
 	"github.com/hkdb/app/db"
+	"github.com/hkdb/app/env"
 
 	"fmt"
-	"strings"
 	"os"
+	"strings"
 )
 
 func ListRepo(pm, r string) {
-	
-	repos, err := db.ReadPkgSlice("packages","repo", pm)
+
+	repos, err := db.ReadPkgSlice("packages", "repo", pm)
 	if err != nil {
 		PrintErrorExit("Read Repo List Error:", err)
 	}
@@ -42,7 +42,7 @@ func ListRepo(pm, r string) {
 
 	fmt.Println("\n")
 
-} 
+}
 
 func IsPPA(p string) bool {
 
@@ -68,14 +68,14 @@ func IsScript(p string) bool {
 
 func IsUrl(p string) bool {
 
-  http_last := 7
-  https_last := 8
-  if len(p) <= 8 {
-    http_last = len(p)-1
-    https_last = len(p)-1
-  }
-  http := p[0:http_last]
-  https := p[0:https_last]
+	http_last := 7
+	https_last := 8
+	if len(p) <= 8 {
+		http_last = len(p) - 1
+		https_last = len(p) - 1
+	}
+	http := p[0:http_last]
+	https := p[0:https_last]
 
 	if http == "http://" || https == "https://" {
 		return true
@@ -86,10 +86,10 @@ func IsUrl(p string) bool {
 }
 
 func GetRepoType(s string) string {
-	
+
 	// Check if it's PPA
 	isPPA := IsPPA(s)
-	
+
 	if isPPA == true {
 		return "ppa"
 	}
@@ -148,31 +148,31 @@ func GetRepoName(p, pType, g string) string {
 	default:
 		PrintErrorMsgExit("Error:", "Source format error")
 	}
-	
+
 	return ""
 
 }
 
 func GetRepoRestoreType(pm, repo string) string {
 
-		rTag := IsPPA(repo)
-		if rTag == true {
-			return "ppa"
+	rTag := IsPPA(repo)
+	if rTag == true {
+		return "ppa"
+	}
+
+	rType := ""
+	prFile := env.DBDir + "/packages/repo/local/" + pm + "/" + repo + ".json"
+	if _, err := os.Stat(prFile); os.IsExist(err) {
+		rType = "json"
+	}
+	psFile := env.DBDir + "/packages/repo/local/" + pm + "/" + repo + ".sh"
+	if _, err := os.Stat(psFile); os.IsExist(err) {
+		if rType == "json" {
+			PrintErrorMsgExit("Record Error:", "Something is wrong with your app records. There should not be both a .json and .sh file referencing "+repo+"...")
 		}
-		
-		rType := ""
-		prFile := env.DBDir + "/packages/repo/local/" + pm + "/" + repo + ".json"
-		if _, err := os.Stat(prFile); os.IsExist(err) {
-			rType = "json"
-		}
-		psFile := env.DBDir + "/packages/repo/local/" + pm + "/" + repo + ".sh"
-		if _, err := os.Stat(psFile); os.IsExist(err) {
-			if rType == "json" {
-				PrintErrorMsgExit("Record Error:", "Something is wrong with your app records. There should not be both a .json and .sh file referencing " + repo + "...")
-			}
-			rType = "sh"
-		}
-		
-		return rType
+		rType = "sh"
+	}
+
+	return rType
 
 }

--- a/windows/scoop.go
+++ b/windows/scoop.go
@@ -1,3 +1,1 @@
 package windows
-
-


### PR DESCRIPTION
I have added the `goimports` linter thru pre-commits.

To make it works on your machine you will need to have `pre-commit` & `golangci-lint` installed (used `brew` on my `Fedora`) and do a `pre-commit install` on the root of the repo.

If you want to perform manually the linting of all the files you can do a `pre-commit run --all-files` (I did it for the second commit of this branch).

Otherwise everytime a commit is made the linting is also made on all the files.

I've only enabled `goimports` but if you want you can play with more (`golangci-lint linters` to have the complete list).

For example adding `gosimple` in the `.golangci.yaml` config will check for code simplification like reducing:
```
if test == true {
...
```
into:
```
if test {
...
```