### PR TITLE
Enable: fix package manager name

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -75,7 +75,7 @@ func ParseFlags() env.Flags {
 			}
 		}
 		if a == "enable" || a == "disable" {
-			if *m == "apt" || *m == "dnf" || *m == "pacman" || *m == "pkg" {
+			if p == "apt" || p == "dnf" || p == "pacman" || p == "pkg" {
 				utils.PrintErrorMsgExit("Native package managers cannot be enabled/disabled...\n", "")
 			}
 		}

--- a/mgr/process.go
+++ b/mgr/process.go
@@ -703,8 +703,8 @@ func execute(m, a, p, g, c string, classic bool, tag string) {
 		}
 	case "enable":
 
-		fmt.Println(m)
-		switch m {
+		fmt.Println(p)
+		switch p {
 		case "yay":
 			env.Yay = true
 			utils.EditSettings("YAY = ", "y")


### PR DESCRIPTION
Using `app enable packageManagerName` was failing cause the code was checking the system package manager and not the one provided by `packageManagerName`.
Fixed.