### PR TITLE
Install: sort packages name

### DIFF
--- a/db/packages.go
+++ b/db/packages.go
@@ -53,6 +53,9 @@ func RecordPkg(root, col, pm, p string) error {
 	
 	// Assemble new string	
 	pkgs := current + " " + p
+	sPkgs := strings.Split(strings.TrimSpace(pkgs), " ")
+	slices.Sort(sPkgs)
+	pkgs = strings.Join(sPkgs, " ")
 
 	// Write new entry
 	werr := writePkgsEntry(root, col, pm, pkgs)


### PR DESCRIPTION
This PR makes packages name sorted alphabetically in their respective `.json`.
It's easier to read and better to spot differences when you commit your config into a `dotfiles` repo.