### PR TITLE
Restore: brew fix

### DIFF
--- a/flatpak/flatpak.go
+++ b/flatpak/flatpak.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"fmt"
+	"strings"
 )
 
 var mgr = "flatpak"
@@ -118,7 +119,8 @@ func InstallAll() {
 		utils.PrintErrorExit("Flatpak - Read ERROR:", fperr)
 		os.Exit(1)
 	}
-	installAll := exec.Command(mgr, "install", pkgs)
+	args := append([]string{"install"}, strings.Split(pkgs, " ")...)
+	installAll := exec.Command(mgr, args...)
 	utils.RunCmd(installAll, "Installation Error:")
 
 }

--- a/macos/brew.go
+++ b/macos/brew.go
@@ -1,6 +1,8 @@
 package macos
 
 import (
+	"strings"
+
 	"github.com/hkdb/app/db"
 	"github.com/hkdb/app/utils"
 
@@ -118,7 +120,8 @@ func InstallAll() {
 		utils.PrintErrorExit("Homebrew - Read ERROR:", fperr)
 		os.Exit(1)
 	}
-	installAll := exec.Command(mgr, "install", pkgs)
+	args := append([]string{"install"}, strings.Split(pkgs, " ")...)
+	installAll := exec.Command(mgr, args...)
 	utils.RunCmd(installAll, "Installation Error:")
 
 }


### PR DESCRIPTION
I was trying to restore my brew packages with this config:
```
{
	"packages": "bat bottom chezmoi eza fd fzf git-lfs golangci-lint micro neofetch pre-commit streamlink"
}
```
Doing so resulted with the following error:
```
Error: No formulae found for bat bottom chezmoi eza fd fzf git-lfs golangci-lint micro neofetch pre-commit streamlink.
```
It seems that passing all packages with one string does not work.
I think I've find the cleanest/shortest way to pass a dynamic number of packages name to the cmd.

It probably does apply to all the rest of the package managers but I did only test `brew`.