### PR TITLE
Github: disable go workflow cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.21.4'
+          cache: false
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Hi 👋

Sorry for not having the time to address the issue #17 before.

The easiest solution to fix this (I hope) is to completely disable go cache.

Considering that [18 issues on 34](https://github.com/actions/setup-go/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20cache) on the [setup-go repo](https://github.com/actions/setup-go) are related to caching issue I think it's the way to treat that problem (some of them are even giving this as a solution).