### PR TITLE
Fix installer's compatibility with Fish shell

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ if [[ $SHELLTYPE == "zsh" ]]; then
 fi
 
 if [[ $SHELLTYPE == "fish" ]]; then
-  SHELLRC="$HOME/.config/fish/config.fish"
+  SHELLRC="$HOME/.config/fish/conf.d/00-app.fish"
 fi
 
 if [[ $SHELLRC == "none" ]]; then
@@ -131,15 +131,36 @@ if [[ ! -d "$HOME/.local/bin" ]]; then
 fi
 
 echo -e "✅️ Making sure $HOME/.local/bin is in PATH...\n"
+
+# Notice: Fish shell uses a different syntax for setting variables.
+if [[ $SHELLTYPE = "fish" ]]; then 
+  SHELLPROFILE_CONTENTS="\
+    if test -d $HOME.local/bin; \n\
+      set -gx PATH "$HOME.local/bin:$PATH"; \n\
+    end\
+  ";
+else
+  SHELLPROFILE_CONTENTS=" \
+    if [ -d \"$HOME/.local/bin\" ]; then \n\
+      PATH=\"$HOME/.local/bin:\$PATH\"\n\
+    fi\
+  ";
+fi
+
+SOURCES_STRING="\
+  # Added by app (https://github.com/hkdb/app) installation \n\
+  source $SHELLPROFILE \
+";
+
 if [[ -f $SHELLPROFILE ]]; then
   PCHECK=$(grep ".local/bin" $SHELLPROFILE)
   if [[ "$PCHECK" == "" ]]; then
-    echo -e "\nif [ -d \"$HOME/.local/bin\" ]; then\n\tPATH=\"$HOME/.local/bin:\$PATH\"\nfi" >> $SHELLPROFILE
-    echo -e "\n# Added by app (https://github.com/hkdb/app) installation\nsource $SHELLPROFILE" >> $SHELLRC
+    echo -e $SHELLPROFILE_CONTENTS >> $SHELLPROFILE
+    echo -e $SOURCES_STRING >> $SHELLRC
   fi
 else
-    echo -e "\nif [ -d \"$HOME/.local/bin\" ]; then\n\tPATH=\"$HOME/.local/bin:\$PATH\"\nfi" >> $SHELLPROFILE
-    echo -e "\n# Added by app (https://github.com/hkdb/app) installation\nsource $SHELLPROFILE" >> $SHELLRC
+    echo -e $SHELLPROFILE_CONTENTS >> $SHELLPROFILE
+    echo -e $SOURCES_STRING >> $SHELLRC
 fi
 
 DISTRO=""

--- a/install.sh
+++ b/install.sh
@@ -134,17 +134,9 @@ echo -e "✅️ Making sure $HOME/.local/bin is in PATH...\n"
 
 # Notice: Fish shell uses a different syntax for setting variables.
 if [[ $SHELLTYPE = "fish" ]]; then 
-  SHELLPROFILE_CONTENTS="\
-    if test -d $HOME.local/bin; \n\
-      set -gx PATH "$HOME.local/bin:$PATH"; \n\
-    end\
-  ";
+  SHELLPROFILE_CONTENTS="if test -d $HOME.local/bin;\n  set -gx PATH "$HOME.local/bin:$PATH";\nend";
 else
-  SHELLPROFILE_CONTENTS=" \
-    if [ -d \"$HOME/.local/bin\" ]; then \n\
-      PATH=\"$HOME/.local/bin:\$PATH\"\n\
-    fi\
-  ";
+  SHELLPROFILE_CONTENTS="if [ -d \"$HOME/.local/bin\" ]; then\n  PATH=\"$HOME/.local/bin:\$PATH\"\nfi";
 fi
 
 SOURCES_STRING="\


### PR DESCRIPTION
Your installer script wasn't compatible with Fish shell, but I got it. 
Problem is that the syntax is too different between Fish and the other shells. 
- Setting variables looks like `set VAR val`, not `$VAR="val"`. 
- Conditionals are similarly weird compared to Bash. https://fishshell.com/docs/current/cmds/if.html

Fixes: 
- Extracted contents of $SHELLPROFILE and $SHELLRC injections into constants
- Added translation to $SHELLPROFILE_CONTENTS for Fish shell
- Minor thing: Tweaked $SHELLRC to use Fish's modular configs as they prefer.

I did some testing, though I might've missed something, shout if I did. 